### PR TITLE
Feat/4 cicd [FEAT] CI/CD 파이프라인 초기 구축 

### DIFF
--- a/.github/workflows/ForkRepoCI.yml
+++ b/.github/workflows/ForkRepoCI.yml
@@ -15,7 +15,10 @@ jobs:
   test-and-analyze:
     runs-on: ubuntu-22.04
 
-    if: ${{ secrets.REPO_ROLE == 'FORK_REPO'}}  # Fork된 레포인지 체크
+    env:
+      REPO_ROLE: ${{ secrets.REPO_ROLE }}  # 환경 변수로 할당
+
+    if: env.REPO_ROLE == 'FORK_REPO'  # 환경 변수를 이용해 비교
 
     steps:
       - name: Check out the repository

--- a/.github/workflows/ForkRepoCI.yml
+++ b/.github/workflows/ForkRepoCI.yml
@@ -15,7 +15,7 @@ jobs:
   test-and-analyze:
     runs-on: ubuntu-22.04
 
-    if: github.event.pull_request.head.repo.fork == true  # Fork된 레포인지 체크
+    if: ${{secrets.REPO_ROLE == 'FORK_REPO'}}  # Fork된 레포인지 체크
 
     steps:
       - name: Check out the repository

--- a/.github/workflows/ForkRepoCI.yml
+++ b/.github/workflows/ForkRepoCI.yml
@@ -15,7 +15,7 @@ jobs:
   test-and-analyze:
     runs-on: ubuntu-22.04
 
-    if: ${{secrets.REPO_ROLE == 'FORK_REPO'}}  # Fork된 레포인지 체크
+    if: ${{ secrets.REPO_ROLE == 'FORK_REPO'}}  # Fork된 레포인지 체크
 
     steps:
       - name: Check out the repository

--- a/.github/workflows/ForkRepoCI.yml
+++ b/.github/workflows/ForkRepoCI.yml
@@ -15,12 +15,19 @@ jobs:
   test-and-analyze:
     runs-on: ubuntu-22.04
 
-    env:
-      REPO_ROLE: ${{ secrets.REPO_ROLE }}  # 환경 변수로 할당
-
-    if: env.REPO_ROLE == 'FORK_REPO'  # 환경 변수를 이용해 비교
-
     steps:
+      - name: Check REPO_ROLE
+        env:
+          REPO_ROLE: ${{ secrets.REPO_ROLE }}
+
+        run: |
+          if [ "$REPO_ROLE" == "FORK_REPO" ]; then
+            echo "Running CI for Forked Repo..."
+          else
+            echo "Skipping CI (Not a Forked Repo)"
+            exit 1
+          fi
+
       - name: Check out the repository
         uses: actions/checkout@v4
 

--- a/.github/workflows/ForkRepoCI.yml
+++ b/.github/workflows/ForkRepoCI.yml
@@ -1,0 +1,59 @@
+name: CI/CD Workflow for Forked Repo
+
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  checks: write
+  pull-requests: write
+
+jobs:
+  # ✅ Fork 레포에서 PR이 들어오면 Jacoco & SonarCloud 실행
+  test-and-analyze:
+    runs-on: ubuntu-22.04
+
+    if: github.event.pull_request.head.repo.fork == true  # Fork된 레포인지 체크
+
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+          cache: 'gradle'
+
+      - name: Build with Gradle
+        run: chmod +x gradlew
+
+      - name: Test with Gradle
+        run: ./gradlew build test jacocoTestReport
+
+      - name: Add coverage to PR
+        id: jacoco
+        uses: madrapps/jacoco-report@v1.6.1
+        with:
+          paths: |
+            ${{ github.workspace }}/**/build/reports/jacoco/**/jacocoTestReport.xml
+          token: ${{ secrets.GITHUB_TOKEN }}
+          min-coverage-overall: 80
+          min-coverage-changed-files: 80
+
+      - name: Cache SonarCloud packages
+        uses: actions/cache@v3
+        with:
+          path: ~/.sonar/cache
+          key: ${{ runner.os }}-sonar
+          restore-keys: ${{ runner.os }}-sonar
+
+      - name: Build and analyze (Sonar Scan)
+        run: ./gradlew build jacocoTestReport sonar --info
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+

--- a/.github/workflows/OriginRepoCD.yml
+++ b/.github/workflows/OriginRepoCD.yml
@@ -7,7 +7,10 @@ on:
 jobs:
   Docker_Build_And_Push:
 
-    if: ${{secrets.REPO_ROLE == 'ORIGIN_REPO'}}  # 코드를 배포할 레포인지 체크
+    env:
+      REPO_ROLE: ${{ secrets.REPO_ROLE }}  # 환경 변수로 할당
+
+    if: env.REPO_ROLE == 'ORIGIN_REPO'  # 환경 변수를 이용해 비교
 
     runs-on: ubuntu-22.04
 

--- a/.github/workflows/OriginRepoCD.yml
+++ b/.github/workflows/OriginRepoCD.yml
@@ -26,13 +26,6 @@ jobs:
       - name: Check out the repository
         uses: actions/checkout@v3
 
-#      # 2. properties 파일 설정 (JASYPT를 사용하므로 패스)
-#      - name: Set PROPERTIES file
-#        run: |
-#          mkdir -p ./src/main/resources
-#          [ ! -f "./src/main/resources/application.properties" ] && echo "${{ secrets.APPLICATION_PROD_PROPERTIES }}" | base64 --decode > ./src/main/resources/application.properties
-#          find src
-
       # 2. Docker Hub 로그인
       - name: Log in to Docker Hub
         run: |

--- a/.github/workflows/OriginRepoCD.yml
+++ b/.github/workflows/OriginRepoCD.yml
@@ -7,14 +7,21 @@ on:
 jobs:
   Docker_Build_And_Push:
 
-    env:
-      REPO_ROLE: ${{ secrets.REPO_ROLE }}  # 환경 변수로 할당
-
-    if: env.REPO_ROLE == 'ORIGIN_REPO'  # 환경 변수를 이용해 비교
-
     runs-on: ubuntu-22.04
 
     steps:
+      - name: Check REPO_ROLE
+        env:
+          REPO_ROLE: ${{ secrets.REPO_ROLE }}
+
+        run: |
+          if [ "$REPO_ROLE" == "ORIGIN_REPO" ]; then
+            echo "Running CI for Forked Repo..."
+          else
+            echo "Skipping CI (Not a Forked Repo)"
+            exit 1
+          fi
+
       # 1. 리포지토리 코드 체크아웃
       - name: Check out the repository
         uses: actions/checkout@v3

--- a/.github/workflows/OriginRepoCD.yml
+++ b/.github/workflows/OriginRepoCD.yml
@@ -1,0 +1,61 @@
+name: CD Pipeline for Main Branch
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  Docker_Build_And_Push:
+
+    if: github.event.pull_request.head.repo.fork != true  # 원본 레포인지 체크
+
+    runs-on: ubuntu-22.04
+
+    steps:
+      # 1. 리포지토리 코드 체크아웃
+      - name: Check out the repository
+        uses: actions/checkout@v3
+
+#      # 2. properties 파일 설정 (JASYPT를 사용하므로 패스)
+#      - name: Set PROPERTIES file
+#        run: |
+#          mkdir -p ./src/main/resources
+#          [ ! -f "./src/main/resources/application.properties" ] && echo "${{ secrets.APPLICATION_PROD_PROPERTIES }}" | base64 --decode > ./src/main/resources/application.properties
+#          find src
+
+      # 2. Docker Hub 로그인
+      - name: Log in to Docker Hub
+        run: |
+          echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
+
+      # 3. 현재 디렉토리 파일 리스트 확인 (디버깅 용도)
+      - name: List files in current directory
+        run: ls -la
+
+      # 4. Docker 이미지 빌드 및 푸시
+      - name: Build and Push Docker image
+        # JASYPT_ENCRYPTOR_PASSWORD 가 secrets에 들어가야 함.
+        run: |
+          docker buildx build --platform linux/amd64 --push --build-arg JASYPT_ENCRYPTOR_PASSWORD=${{ secrets.JASYPT_KEY }} --tag 5hseok/dodal-server:0.0.1 -f ./Dockerfile .
+
+  Deploy:
+    needs: Docker_Build_And_Push
+    runs-on: ubuntu-22.04
+
+    steps:
+      # EC2에 SSH로 연결하여 배포
+      - name: Deploy to EC2 via SSH
+        uses: appleboy/ssh-action@v0.1.5
+        with:
+          host: ${{ secrets.EC2_HOST }}
+          username: ${{ secrets.EC2_USER }}
+          key: ${{ secrets.EC2_SSH_KEY }}
+          port: 22
+          script: |            
+            cd /home/ubuntu 
+            sudo docker pull 5hseok/dodal-server:0.0.1
+            
+            sudo docker stop dodal-server || true
+            sudo docker rm dodal-server || true
+            
+            sudo docker run -d --name spring_server -p 8080:8080 5hseok/dodal-server:0.0.1

--- a/.github/workflows/OriginRepoCD.yml
+++ b/.github/workflows/OriginRepoCD.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   Docker_Build_And_Push:
 
-    if: github.event.pull_request.head.repo.fork != true  # 원본 레포인지 체크
+    if: ${{secrets.REPO_ROLE == 'ORIGIN_REPO'}}  # 코드를 배포할 레포인지 체크
 
     runs-on: ubuntu-22.04
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,29 @@
+FROM openjdk:17-jdk-slim AS builder
+WORKDIR /buildMyApp
+
+ARG JASYPT_ENCRYPTOR_PASSWORD
+ENV JASYPT_ENCRYPTOR_PASSWORD=${JASYPT_ENCRYPTOR_PASSWORD}
+
+# Gradle Wrapper 복사
+COPY gradlew .
+COPY gradle gradle
+RUN chmod +x gradlew
+
+# 의존성 파일 복사 및 다운로드
+COPY build.gradle .
+COPY settings.gradle .
+
+# 의존성 다운로드
+RUN ./gradlew dependencies
+
+# 소스코드 복사 및 빌드
+COPY ./ ./
+# PR에서 테스트를 이미 Jacoco 등으로 검증했기 때문에 배포를 위한 빌드 시 테스트를 제외
+RUN ./gradlew clean build -x test
+
+# 실행 스테이지
+FROM openjdk:17-jdk-slim
+WORKDIR /dodalApp
+COPY --from=builder /buildMyApp/build/libs/*.jar dodalAppExcute.jar
+
+ENTRYPOINT ["java", "-Duser.timezone=Asia/Seoul", "-jar", "dodalAppExcute.jar"]

--- a/build.gradle
+++ b/build.gradle
@@ -83,14 +83,11 @@ jacocoTestCoverageVerification {
     }
 }
 
-//sonar {
-//    properties {
-//        property 'sonar.host.url', 'https://sonarcloud.io'
-//        property 'sonar.organization', '???'
-//        property 'sonar.projectKey', 'SonarCloud-information에 있는 값을 넣어주시면 됩니다.'
-//        property 'sonar.coverage.jacoco.xmlReportPaths', '${buildDir}/reports/jacoco/test/jacocoTestReport.xml'
-//    }
-//}
-
-// 1. SonarCloud를 사용하려면 레포 주인이어야 한다.
-// 2. SonarCloud에서 무료 플랜을 사용하려면 레포 주인이어야 한다.
+sonar {
+    properties {
+        property 'sonar.host.url', 'https://sonarcloud.io'
+        property 'sonar.organization', '5hseok'
+        property 'sonar.projectKey', '5hseok_DODAL_BE_SERVER'
+        property 'sonar.coverage.jacoco.xmlReportPaths', '${buildDir}/reports/jacoco/test/jacocoTestReport.xml'
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -17,4 +17,67 @@ dependencies {
 
 test {
     useJUnitPlatform()
+    finalizedBy 'jacocoTestReport'
+}
+
+// Jacoco 설정
+jacoco {
+    toolVersion = "0.8.12"
+//    // report가 생성될 디렉토리 설정
+//    // 설정하지 않는다면 reports/jacoco가 기본 값
+//    reportsDirectory = layout.buildDirectory.dir('customJacocoReportDir')
+}
+
+jacocoTestReport {
+    dependsOn test
+    reports {
+
+        html.required = true // 로컬에서 확인용으로 html 리포트 파일 생성
+        html.outputLocation = layout.buildDirectory.dir('jacocoHtml')
+
+        xml.required = true  // SonarCloud로 전송하기 위해 XML 리포트 생성
+        xml.outputLocation = layout.buildDirectory.file('jacoco.xml')
+
+        finalizedBy 'jacocoTestCoverageVerification'
+    }
+}
+
+jacocoTestCoverageVerification {
+    violationRules {
+        rule {
+            enabled = true // 이 rule을 적용할 것이다.
+            element = 'CLASS' // class 단위로
+
+            // 브랜치 커버리지 최소 60%
+            limit {
+                counter = 'BRANCH'
+                value = 'COVEREDRATIO'
+                minimum = 0.60
+            }
+
+            // 라인 커버리지 최소한 80%
+            limit {
+                counter = 'LINE'
+                value = 'COVEREDRATIO'
+                minimum = 0.80
+            }
+
+            // 빈 줄을 제외한 코드의 라인수 최대 300라인
+            limit {
+                counter = 'LINE'
+                value = 'TOTALCOUNT'
+                maximum = 0.3
+            }
+
+//            // 커버리지 체크를 제외할 클래스들
+//            excludes = [
+//                    '**.*Application*',
+//                    '**.*Request*',
+//                    '**.*Response*',
+//                    '**.*OAuthClient*',
+//                    '**.*Interceptor*',
+//                    '**.*Exception*',
+//            ] + Qdomains
+        }
+    }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,8 @@
 plugins {
     id 'java'
     id 'jacoco'
+    id 'org.sonarqube' version '4.4.1.3373'
+
 }
 
 group = 'ac.dnd'
@@ -33,16 +35,15 @@ jacocoTestReport {
     reports {
 
         html.required = true // 로컬에서 확인용으로 html 리포트 파일 생성
-        html.outputLocation = layout.buildDirectory.dir('jacocoHtml')
-
         xml.required = true  // SonarCloud로 전송하기 위해 XML 리포트 생성
-        xml.outputLocation = layout.buildDirectory.file('jacoco.xml')
+        csv.required = false
 
         finalizedBy 'jacocoTestCoverageVerification'
     }
 }
 
 jacocoTestCoverageVerification {
+    dependsOn jacocoTestReport
     violationRules {
         rule {
             enabled = true // 이 rule을 적용할 것이다.
@@ -81,3 +82,15 @@ jacocoTestCoverageVerification {
         }
     }
 }
+
+//sonar {
+//    properties {
+//        property 'sonar.host.url', 'https://sonarcloud.io'
+//        property 'sonar.organization', '???'
+//        property 'sonar.projectKey', 'SonarCloud-information에 있는 값을 넣어주시면 됩니다.'
+//        property 'sonar.coverage.jacoco.xmlReportPaths', '${buildDir}/reports/jacoco/test/jacocoTestReport.xml'
+//    }
+//}
+
+// 1. SonarCloud를 사용하려면 레포 주인이어야 한다.
+// 2. SonarCloud에서 무료 플랜을 사용하려면 레포 주인이어야 한다.

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id 'java'
+    id 'jacoco'
 }
 
 group = 'ac.dnd'


### PR DESCRIPTION
## #️⃣ Related Issue

Linked Feature backlog: #4 

## 📝 Purpose of PR

Jacoco와 SonarCloud를 사용한 CI/CD 파이프라인 구축 및 지속적인 코드 관리

## Contents

Jacoco와 SonarCloud 사용해서 DODAL_BE_SERVER에는 CI 작업을 실행하도록 했고, dnd 쪽 레포로 보내서 dnd 레포 main에 push 되면 CD 작업이 실행하도록 했습니다.  

다만, build.gradle애서의 Jacoco 커버지리 설정 및 스캔 범위와

```
// 브랜치 커버리지 최소 60%
            limit {
                counter = 'BRANCH'
                value = 'COVEREDRATIO'
                minimum = 0.60
            }

            // 라인 커버리지 최소한 80%
            limit {
                counter = 'LINE'
                value = 'COVEREDRATIO'
                minimum = 0.80
            }
...
//            // 커버리지 체크를 제외할 클래스들
//            excludes = [
//                    '**.*Application*',
//                    '**.*Request*',
//                    '**.*Response*',
//                    '**.*OAuthClient*',
//                    '**.*Interceptor*',
//                    '**.*Exception*',
//            ] + Qdomains
```

Jacoco와 SonarCloud가 정상적으로 이루어지는 지는 지속적인 테스트가 필요할 것 같습니다. 

## Checklist

-   [x] Does commit messages follow the convention?
-   [] Are variable names brief but descriptive?
-   [x] Is the code clean and easy to understand?
-   [ ] If a new feature has been added, or a bug fixed, has a test been added to confirm good behavior?
-   [ ] Does the test successfully test edge and corner cases?

## 💬 Review Requirements (Optional)

