### PR TITLE
[FEAT] Add CompletedDate to Plan

### DIFF
--- a/src/main/java/ac/dnd/dodal/domain/plan/model/Plan.java
+++ b/src/main/java/ac/dnd/dodal/domain/plan/model/Plan.java
@@ -64,6 +64,8 @@ public class Plan extends BaseEntity {
     @Column(nullable = false)
     private LocalDateTime endDate;
 
+    private LocalDateTime completedDate;
+
     public void complete(PlanStatus status, List<PlanFeedback> feedbacks) {
         if (this.deletedAt != null) {
             throw new ForbiddenException(PlanExceptionCode.PLAN_ALREADY_DELETED);
@@ -77,10 +79,14 @@ public class Plan extends BaseEntity {
         if (feedbacks == null || feedbacks.size() == 0) {
             throw new BadRequestException(PlanExceptionCode.REQUIRED_FEEDBACK);
         }
+        if (status == null || status == PlanStatus.NONE) {
+            throw new BadRequestException(PlanExceptionCode.INVALID_PLAN_STATUS);
+        }
 
         this.status = status;
         this.guide = GuidianceService.generateGuide(feedbacks);
         feedbacks.forEach(feedback -> feedback.setPlan(this));
+        setCompletedDate();
     }
 
     public Plan(String title, LocalDateTime startDate, LocalDateTime endDate) {
@@ -94,7 +100,7 @@ public class Plan extends BaseEntity {
 
     public Plan(Long planId, Goal goal, PlanHistory history,
             String title, PlanStatus status, String guide, 
-            LocalDateTime startDate, LocalDateTime endDate,
+            LocalDateTime startDate, LocalDateTime endDate, LocalDateTime completedDate,
             LocalDateTime createdAt, LocalDateTime updatedAt, LocalDateTime deletedAt) {
         super(createdAt, updatedAt, deletedAt);
 
@@ -109,6 +115,7 @@ public class Plan extends BaseEntity {
         this.guide = guide;
         this.startDate = startDate;
         this.endDate = endDate;
+        this.completedDate = completedDate;
     }
 
     public void setGoal(Goal goal) {
@@ -124,7 +131,7 @@ public class Plan extends BaseEntity {
     }
 
     public boolean isCompleted() {
-        return this.status != PlanStatus.NONE;
+        return this.status != PlanStatus.NONE || this.completedDate != null;
     }
 
     private void validateTitle(String title) {
@@ -139,6 +146,14 @@ public class Plan extends BaseEntity {
     private void validateDate(LocalDateTime startDate, LocalDateTime endDate) {
         if (startDate.isAfter(endDate)) {
             throw new BadRequestException(PlanExceptionCode.PLAN_START_DATE_AFTER_END_DATE);
+        }
+    }
+
+    private void setCompletedDate() {
+        this.completedDate = LocalDateTime.now();
+
+        if (this.endDate.isBefore(LocalDateTime.now())) {
+            this.completedDate = this.endDate;
         }
     }
 }

--- a/src/main/resources/db/migration/V7__add_completedDate_to_plans.sql
+++ b/src/main/resources/db/migration/V7__add_completedDate_to_plans.sql
@@ -1,0 +1,8 @@
+ALTER TABLE plans ADD COLUMN completed_time TIMESTAMP;
+
+UPDATE plans
+SET completed_time = CASE
+    WHEN status = 'NONE' THEN NULL
+    WHEN status IN ('SUCCESS', 'FAILURE') THEN end_date
+    ELSE completed_time
+END;

--- a/src/test/java/ac/dnd/dodal/domain/plan/PlanFixture.java
+++ b/src/test/java/ac/dnd/dodal/domain/plan/PlanFixture.java
@@ -21,95 +21,95 @@ public class PlanFixture {
     public static Plan plan() {
         return new Plan(PLAN_ID, GOAL, HISTORY,
             "title", PlanStatus.NONE, null,
-            LocalDateTime.now(), LocalDateTime.now().plusDays(1),
+            LocalDateTime.now(), LocalDateTime.now().plusDays(1), null,
             LocalDateTime.now(), LocalDateTime.now(), null);
     }
 
     public static Plan plan(String title, PlanStatus status, String guide,
-            LocalDateTime startDate, LocalDateTime endDate) {
+            LocalDateTime startDate, LocalDateTime endDate, LocalDateTime completedDate) {
         return new Plan(PLAN_ID, GOAL, HISTORY, title, status, guide, startDate, endDate,
-            LocalDateTime.now(), LocalDateTime.now(), null);
+            completedDate, LocalDateTime.now(), LocalDateTime.now(), null);
     }
 
     public static Plan deletedPlan() {
         return new Plan(PLAN_ID, GOAL, HISTORY,
             "title", PlanStatus.NONE, null,
-            LocalDateTime.now(), LocalDateTime.now().plusDays(1),
+            LocalDateTime.now(), LocalDateTime.now().plusDays(1), null,
             LocalDateTime.now(), LocalDateTime.now(), LocalDateTime.now());
     }
 
     public static Plan deletedPlan(String title, PlanStatus status, String guide,
-            LocalDateTime startDate, LocalDateTime endDate) {
+            LocalDateTime startDate, LocalDateTime endDate, LocalDateTime completedDate) {
         return new Plan(PLAN_ID, GOAL, HISTORY,
-            title, status, guide, startDate, endDate,
+            title, status, guide, startDate, endDate, completedDate,
             LocalDateTime.now(), LocalDateTime.now(), LocalDateTime.now());
     }
 
     public static Plan successPlan() {
         return new Plan(PLAN_ID, GOAL, HISTORY,
             "title", PlanStatus.SUCCESS, "guide",
-            LocalDateTime.now(), LocalDateTime.now().plusDays(1),
+            LocalDateTime.now(), LocalDateTime.now().plusDays(1), LocalDateTime.now().plusDays(1),
             LocalDateTime.now(), LocalDateTime.now(), null);
     }
 
     public static Plan successPlan(String title, String guide,
-            LocalDateTime startDate, LocalDateTime endDate) {
+            LocalDateTime startDate, LocalDateTime endDate, LocalDateTime completedDate) {
         return new Plan(PLAN_ID, GOAL, HISTORY,
-            title, PlanStatus.SUCCESS, guide, startDate, endDate,
+            title, PlanStatus.SUCCESS, guide, startDate, endDate, completedDate,
             LocalDateTime.now(), LocalDateTime.now(), null);
     }
 
     public static Plan failurePlan() {
         return new Plan(PLAN_ID, GOAL, HISTORY, "title", PlanStatus.FAILURE, "guide",
-            LocalDateTime.now(), LocalDateTime.now().plusDays(1), LocalDateTime.now(),
-            LocalDateTime.now(), null);
+                LocalDateTime.now(), LocalDateTime.now().plusDays(1), LocalDateTime.now().plusDays(1),
+                LocalDateTime.now(), LocalDateTime.now(), null);
     }
 
     public static Plan failurePlan(String title, String guide,
-            LocalDateTime startDate, LocalDateTime endDate) {
+            LocalDateTime startDate, LocalDateTime endDate, LocalDateTime completedDate) {
         return new Plan(PLAN_ID, GOAL, HISTORY,
-            title, PlanStatus.FAILURE, guide, startDate, endDate,
+            title, PlanStatus.FAILURE, guide, startDate, endDate, completedDate,
             LocalDateTime.now(), LocalDateTime.now(), null);
     }
 
     public static Plan tommorowStartPlan() {
         return new Plan(PLAN_ID, GOAL, HISTORY, "title", PlanStatus.NONE, null,
-            LocalDateTime.now().plusDays(1), LocalDateTime.now().plusDays(2),
+            LocalDateTime.now().plusDays(1), LocalDateTime.now().plusDays(2), null,
             LocalDateTime.now(), LocalDateTime.now(), null);
     }
 
     public static List<Plan> monthlyPlan() {
         return Arrays.asList(
             successPlan("success plan", "guide",
-                LocalDateTime.now().minusDays(10), LocalDateTime.now().minusDays(9)),
+                LocalDateTime.now().minusDays(10), LocalDateTime.now().minusDays(9), LocalDateTime.now().minusDays(9)),
             successPlan("success plan", "guide", LocalDateTime.now().minusDays(9),
-                LocalDateTime.now().minusDays(8)),
+                LocalDateTime.now().minusDays(8), LocalDateTime.now().minusDays(8)),
             successPlan("success plan", "guide", LocalDateTime.now().minusDays(8),
-                LocalDateTime.now().minusDays(7)),
+                LocalDateTime.now().minusDays(7), LocalDateTime.now().minusDays(7)),
             successPlan("success plan", "guide", LocalDateTime.now().minusDays(7),
-                LocalDateTime.now().minusDays(6)),
+                LocalDateTime.now().minusDays(6), LocalDateTime.now().minusDays(6)),
             successPlan("success plan", "guide", LocalDateTime.now().minusDays(6),
-                LocalDateTime.now().minusDays(5)),
+                LocalDateTime.now().minusDays(5), LocalDateTime.now().minusDays(5)),
             successPlan("success plan", "guide", LocalDateTime.now().minusDays(5),
-                LocalDateTime.now().minusDays(4)),
+                LocalDateTime.now().minusDays(4), LocalDateTime.now().minusDays(4)),
             successPlan("success plan", "guide", LocalDateTime.now().minusDays(4),
-                LocalDateTime.now().minusDays(3)),
+                LocalDateTime.now().minusDays(3), LocalDateTime.now().minusDays(3)),
             successPlan("success plan", "guide", LocalDateTime.now().minusDays(3),
-                LocalDateTime.now().minusDays(2)),
+                LocalDateTime.now().minusDays(2), LocalDateTime.now().minusDays(2)),
             successPlan("success plan", "guide", LocalDateTime.now().minusDays(2),
-                LocalDateTime.now().minusDays(1)),
+                LocalDateTime.now().minusDays(1), LocalDateTime.now().minusDays(1)),
             successPlan("success plan", "guide", LocalDateTime.now().minusDays(1),
-                LocalDateTime.now()),
+                LocalDateTime.now(), LocalDateTime.now()),
             plan("plan", PlanStatus.NONE, null,
-                LocalDateTime.now(), LocalDateTime.now().plusDays(1)),
+                LocalDateTime.now(), LocalDateTime.now().plusDays(1), null),
             plan("plan", PlanStatus.NONE, null,
-                LocalDateTime.now().plusDays(1), LocalDateTime.now().plusDays(2)),
+                LocalDateTime.now().plusDays(1), LocalDateTime.now().plusDays(2), null),
             plan("plan", PlanStatus.NONE, null,
-                LocalDateTime.now().plusDays(2), LocalDateTime.now().plusDays(3)),
+                LocalDateTime.now().plusDays(2), LocalDateTime.now().plusDays(3), null),
             plan("plan", PlanStatus.NONE, null,
-                LocalDateTime.now().plusDays(3), LocalDateTime.now().plusDays(4)),
+                LocalDateTime.now().plusDays(3), LocalDateTime.now().plusDays(4), null),
             plan("plan", PlanStatus.NONE, null,
-                LocalDateTime.now().plusDays(4), LocalDateTime.now().plusDays(5)));
+                LocalDateTime.now().plusDays(4), LocalDateTime.now().plusDays(5), null));
     }
 
     public static List<Plan> plans() {


### PR DESCRIPTION


## 📝 Purpose of PR

조회 시에 날짜 기준 정렬

## Contents

**히스토리에 날짜와 함께 완료한 계획이 뜰 때 날짜의 기준**
### 현재 상황
- startDate ~ endDate로 되어있어 하나로 특정 불가
- 완료를 누르고 피드백을 제출한 순간을 기준으로 하는 경우
- 실제 수행 시간과 차이 발생
- 그렇다고 endDate 이전에만 완료가 가능하게 하면 정작 수행한 것을 기록을 못할 수 있음
### 결론
- completedDate column을 따로 두어 관리
- startDate ~ endDate 사이에 완료한 경우 해당 시점을 기준으로
- endDate 이후면 endDate로
- startDate 이전에는 완료 불가
