### PR TITLE
[FEAT] Complete Plan Application

### DIFF
--- a/src/main/java/ac/dnd/dodal/application/feedback/repository/PlanFeedbackRepository.java
+++ b/src/main/java/ac/dnd/dodal/application/feedback/repository/PlanFeedbackRepository.java
@@ -1,0 +1,9 @@
+package ac.dnd.dodal.application.feedback.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import ac.dnd.dodal.domain.plan_feedback.model.PlanFeedback;
+import ac.dnd.dodal.domain.plan_feedback.model.PlanFeedbackId;
+
+public interface PlanFeedbackRepository extends JpaRepository<PlanFeedback, PlanFeedbackId> {
+}

--- a/src/main/java/ac/dnd/dodal/application/feedback/service/PlanFeedbackService.java
+++ b/src/main/java/ac/dnd/dodal/application/feedback/service/PlanFeedbackService.java
@@ -1,0 +1,25 @@
+package ac.dnd.dodal.application.feedback.service;
+
+import java.util.List;
+
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.stereotype.Service;
+
+import ac.dnd.dodal.application.feedback.repository.PlanFeedbackRepository;
+import ac.dnd.dodal.domain.plan_feedback.model.PlanFeedback;
+
+@Service
+@RequiredArgsConstructor
+public class PlanFeedbackService {
+
+    private final PlanFeedbackRepository planFeedbackRepository;
+
+    public PlanFeedback save(PlanFeedback planFeedback) {
+        return planFeedbackRepository.save(planFeedback);
+    }
+
+    public List<PlanFeedback> saveAll(List<PlanFeedback> planFeedbacks) {
+        return planFeedbackRepository.saveAll(planFeedbacks);
+    }
+}

--- a/src/main/java/ac/dnd/dodal/application/plan/dto/command/CompletePlanCommand.java
+++ b/src/main/java/ac/dnd/dodal/application/plan/dto/command/CompletePlanCommand.java
@@ -3,6 +3,7 @@ package ac.dnd.dodal.application.plan.dto.command;
 import ac.dnd.dodal.domain.plan.enums.PlanStatus;
 
 public record CompletePlanCommand(
+    Long userId,
     Long planId,
     PlanStatus status,
     String question,

--- a/src/main/java/ac/dnd/dodal/domain/plan/model/Plan.java
+++ b/src/main/java/ac/dnd/dodal/domain/plan/model/Plan.java
@@ -71,7 +71,7 @@ public class Plan extends BaseEntity {
             throw new ForbiddenException(PlanExceptionCode.PLAN_ALREADY_DELETED);
         }
         if (this.isCompleted()) {
-            throw new BadRequestException(PlanExceptionCode.PLAN_ALREADY_COMPLETED);
+            throw new ForbiddenException(PlanExceptionCode.PLAN_ALREADY_COMPLETED);
         }
         if (this.startDate.isAfter(LocalDateTime.now())) {
             throw new BadRequestException(PlanExceptionCode.PLAN_SUCCEED_AFTER_START_DATE);

--- a/src/main/java/ac/dnd/dodal/domain/plan_feedback/model/PlanFeedback.java
+++ b/src/main/java/ac/dnd/dodal/domain/plan_feedback/model/PlanFeedback.java
@@ -3,13 +3,12 @@ package ac.dnd.dodal.domain.plan_feedback.model;
 import java.time.LocalDateTime;
 
 import jakarta.persistence.Entity;
-import jakarta.persistence.Id;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
 import jakarta.persistence.Column;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.IdClass;
 
 import lombok.ToString;
 import lombok.EqualsAndHashCode;
@@ -19,6 +18,7 @@ import lombok.Getter;
 import ac.dnd.dodal.common.model.BaseEntity;
 import ac.dnd.dodal.domain.plan.model.Plan;
 
+@IdClass(PlanFeedbackId.class)
 @Entity(name = "plan_feedbacks")
 @Getter
 @ToString(callSuper = true)
@@ -27,30 +27,27 @@ import ac.dnd.dodal.domain.plan.model.Plan;
 public class PlanFeedback extends BaseEntity {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long planFeedbackId;
-
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "plan_id", nullable = false)
     private Plan plan;
 
+    @Id
     @Column(nullable = false)
     private String question;
 
     @Column(nullable = false)
     private String indicator;
-    
+
     public void setPlan(Plan plan) {
         this.plan = plan;
     }
 
     public PlanFeedback(String question, String indicator) {
-        this(null, null, question, indicator, null, null, null);
+        this(null, question, indicator, null, null, null);
     }
 
-    public PlanFeedback(Long planFeedbackId, Plan plan, String question, String indicator,
-            LocalDateTime createdAt, LocalDateTime updatedAt, LocalDateTime deletedAt) {
-        this.planFeedbackId = planFeedbackId;
+    public PlanFeedback(Plan plan, String question, String indicator, LocalDateTime createdAt,
+            LocalDateTime updatedAt, LocalDateTime deletedAt) {
         this.plan = plan;
         this.question = question;
         this.indicator = indicator;

--- a/src/main/java/ac/dnd/dodal/domain/plan_feedback/model/PlanFeedbackId.java
+++ b/src/main/java/ac/dnd/dodal/domain/plan_feedback/model/PlanFeedbackId.java
@@ -1,0 +1,17 @@
+package ac.dnd.dodal.domain.plan_feedback.model;
+
+import java.io.Serializable;
+
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+import ac.dnd.dodal.domain.plan.model.Plan;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode
+public class PlanFeedbackId implements Serializable {
+    private Plan plan;
+    private String question;
+}

--- a/src/main/java/ac/dnd/dodal/ui/feedback/request/CreateFeedbackRequest.java
+++ b/src/main/java/ac/dnd/dodal/ui/feedback/request/CreateFeedbackRequest.java
@@ -8,8 +8,8 @@ public record CreateFeedbackRequest(
     String indicator
 ) {
 
-    public CompletePlanCommand toCommand(Long planId, PlanStatus status) {
-        return new CompletePlanCommand(planId, status, question, indicator);
+    public CompletePlanCommand toCommand(Long userId, Long planId, PlanStatus status) {
+        return new CompletePlanCommand(userId, planId, status, question, indicator);
     }
 
     public CreateFeedbackRequest(String question, String indicator) {

--- a/src/main/java/ac/dnd/dodal/ui/plan/PlanController.java
+++ b/src/main/java/ac/dnd/dodal/ui/plan/PlanController.java
@@ -9,6 +9,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.PathVariable;
 
+import ac.dnd.dodal.common.annotation.UserId;
 import ac.dnd.dodal.common.response.ApiResponse;
 import ac.dnd.dodal.domain.plan.model.Plan;
 import ac.dnd.dodal.domain.plan.enums.PlanStatus;
@@ -25,11 +26,12 @@ public class PlanController {
 
     @PostMapping("/{planId}/complete")
     public ApiResponse<?> completePlan(
+        @UserId Long userId,
         @PathVariable Long planId,
         @RequestParam String status,
         @RequestBody CreateFeedbackRequest request
     ) {
-        Plan plan = completePlanUseCase.completePlan(request.toCommand(planId, PlanStatus.of(status)));
+        Plan plan = completePlanUseCase.completePlan(request.toCommand(userId, planId, PlanStatus.of(status)));
 
         return ApiResponse.success(PlanElement.of(plan));
     }

--- a/src/main/resources/db/migration/V7__add_completedDate_to_plans.sql
+++ b/src/main/resources/db/migration/V7__add_completedDate_to_plans.sql
@@ -1,8 +1,8 @@
-ALTER TABLE plans ADD COLUMN completed_time TIMESTAMP;
+ALTER TABLE plans ADD COLUMN completed_date TIMESTAMP;
 
 UPDATE plans
-SET completed_time = CASE
+SET completed_date = CASE
     WHEN status = 'NONE' THEN NULL
     WHEN status IN ('SUCCESS', 'FAILURE') THEN end_date
-    ELSE completed_time
+    ELSE completed_date
 END;

--- a/src/main/resources/db/migration/V8__delete_history_guide.sql
+++ b/src/main/resources/db/migration/V8__delete_history_guide.sql
@@ -1,0 +1,1 @@
+ALTER TABLE plan_histories DROP COLUMN guide;

--- a/src/test/java/ac/dnd/dodal/AcceptanceTest.java
+++ b/src/test/java/ac/dnd/dodal/AcceptanceTest.java
@@ -2,10 +2,7 @@ package ac.dnd.dodal;
 
 import java.util.Map;
 
-import jakarta.transaction.Transactional;
-
 import io.restassured.RestAssured;
-
 import org.junit.jupiter.api.BeforeAll;
 
 import org.springframework.boot.test.context.SpringBootTest;
@@ -13,7 +10,6 @@ import org.springframework.test.context.ActiveProfiles;
 
 import ac.dnd.dodal.ui.fixture.UIFixture;
 
-@Transactional
 @ActiveProfiles("test")
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
 public abstract class AcceptanceTest {
@@ -32,7 +28,7 @@ public abstract class AcceptanceTest {
 
     protected static final Long planId = 1L;
     protected static final Long uncompletedPlanId = 15L;
-    protected static final Long latestSuccessPlanIdWithHistory_1 = 16L;
+    protected static final Long latestSuccessPlanIdWithHistory_1 = 17L;
     protected static final Long latestFailurePlanIdWithHistory_2 = 34L;
 
     protected static final Long planHistoryId = 1L;

--- a/src/test/java/ac/dnd/dodal/acceptance/plan/PlanAcceptanceTest.java
+++ b/src/test/java/ac/dnd/dodal/acceptance/plan/PlanAcceptanceTest.java
@@ -3,28 +3,31 @@ package ac.dnd.dodal.acceptance.plan;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Map;
+
+import lombok.extern.slf4j.Slf4j;
+
 import io.restassured.common.mapper.TypeRef;
 import io.restassured.response.Response;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 
 import ac.dnd.dodal.AcceptanceTest;
 import ac.dnd.dodal.acceptance.plan.steps.PlanSteps;
 import ac.dnd.dodal.common.response.ApiResponse;
-import ac.dnd.dodal.domain.plan.model.Plan;
 import ac.dnd.dodal.common.enums.CommonResultCode;
 import ac.dnd.dodal.ui.feedback.request.CreateFeedbackRequest;
 import ac.dnd.dodal.ui.feedback.fixture.FeedbackUIFixture;
 import ac.dnd.dodal.domain.plan.exception.PlanExceptionCode;
 import ac.dnd.dodal.ui.plan.response.PlanElement;
 
+@Slf4j
 public class PlanAcceptanceTest extends AcceptanceTest {
 
     private static final String SUCCESS_STATUS = "success";
     private static final String FAILURE_STATUS = "failure";
+    private Long uncompletedPlanId2 = 32L;
 
     @Test
     @DisplayName("Complete Plan with Success Status Test")
@@ -36,9 +39,10 @@ public class PlanAcceptanceTest extends AcceptanceTest {
         // when
         Response response =
                 PlanSteps.completePlan(uncompletedPlanId, SUCCESS_STATUS, header, feedbackRequest);
-        ApiResponse<Page<Plan>> apiResponse =
-                response.as(new TypeRef<ApiResponse<Page<Plan>>>() {});
+        ApiResponse<PlanElement> apiResponse =
+                response.as(new TypeRef<ApiResponse<PlanElement>>() {});
 
+        log.info("response = {}", response.asString());
         // then 200
         assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
         // COM001
@@ -58,10 +62,11 @@ public class PlanAcceptanceTest extends AcceptanceTest {
 
         // when
         Response response =
-                PlanSteps.completePlan(uncompletedPlanId, FAILURE_STATUS, header, feedbackRequest);
-        ApiResponse<Page<Plan>> apiResponse =
-                response.as(new TypeRef<ApiResponse<Page<Plan>>>() {});
+                PlanSteps.completePlan(uncompletedPlanId2, FAILURE_STATUS, header, feedbackRequest);
+        ApiResponse<PlanElement> apiResponse =
+                response.as(new TypeRef<ApiResponse<PlanElement>>() {});
 
+        log.info("response = {}", response.asString());
         // then 200
         assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
         // COM001
@@ -82,9 +87,10 @@ public class PlanAcceptanceTest extends AcceptanceTest {
         // when
         Response response =
                 PlanSteps.completePlan(uncompletedPlanId, "wrong", header, feedbackRequest);
-        ApiResponse<Page<Plan>> apiResponse =
-                response.as(new TypeRef<ApiResponse<Page<Plan>>>() {});
+        ApiResponse<PlanElement> apiResponse =
+                response.as(new TypeRef<ApiResponse<PlanElement>>() {});
 
+        log.info("response = {}", response.asString());
         // then 403
         assertThat(response.statusCode()).isEqualTo(HttpStatus.FORBIDDEN.value());
         // PLN_009

--- a/src/test/java/ac/dnd/dodal/application/plan/dto/CompletePlanCommandFixture.java
+++ b/src/test/java/ac/dnd/dodal/application/plan/dto/CompletePlanCommandFixture.java
@@ -1,0 +1,28 @@
+package ac.dnd.dodal.application.plan.dto;
+
+import ac.dnd.dodal.domain.plan.enums.PlanStatus;
+import ac.dnd.dodal.application.plan.dto.command.CompletePlanCommand;
+
+public class CompletePlanCommandFixture {
+
+    private static final Long userId = 1L;
+    private static final Long planId = 1L;
+    private static final String question = "question";
+    private static final String indicator = "indicator";
+
+    public static CompletePlanCommand completePlanCommand() {
+        return new CompletePlanCommand(userId, planId, PlanStatus.SUCCESS, question, indicator);
+    }
+
+    public static CompletePlanCommand successPlanCommand() {
+        return new CompletePlanCommand(userId, planId, PlanStatus.SUCCESS, question, indicator);
+    }
+
+    public static CompletePlanCommand failurePlanCommand() {
+        return new CompletePlanCommand(userId, planId, PlanStatus.FAILURE, question, indicator);
+    }
+
+    public static CompletePlanCommand nonePlanCommand() {
+        return new CompletePlanCommand(userId, planId, PlanStatus.NONE, question, indicator);
+    }
+}

--- a/src/test/java/ac/dnd/dodal/domain/feedback/PlanFeedbackFixture.java
+++ b/src/test/java/ac/dnd/dodal/domain/feedback/PlanFeedbackFixture.java
@@ -7,16 +7,15 @@ import ac.dnd.dodal.domain.plan.model.Plan;
 
 public class PlanFeedbackFixture {
 
-    private static final Long PLAN_FEEDBACK_ID = 1L;
     private static final Plan PLAN = PlanFixture.plan();
 
     public static PlanFeedback planFeedback() {
-        return new PlanFeedback(PLAN_FEEDBACK_ID, PLAN, "question", "indicator",
+        return new PlanFeedback(PLAN, "question", "indicator",
                 LocalDateTime.now(), LocalDateTime.now(), null);
     }
 
     public static PlanFeedback deletedPlanFeedback() {
-        return new PlanFeedback(PLAN_FEEDBACK_ID, PLAN, "question", "indicator",
+        return new PlanFeedback(PLAN, "question", "indicator",
                 LocalDateTime.now(), LocalDateTime.now(), LocalDateTime.now());
     }
 }


### PR DESCRIPTION
## #️⃣ Related Issue

Linked Feature backlog: close #40 #41 

## 📝 Purpose of PR

complete plan 로직 구현

## Contents
- planFeedbackService: only save methods
- PlanCommandService에 CompletePlan method
- unit tests

### Issue: Transactional with AcceptanceTest
RestAssured는 Transactional이 적용되지 않는 별도의 스레드를 만들어 동작하므로 Transactional이 동작하지 않는다.
이로 인해 테스트들이 독립적으로 수행되지 않는다는 문제가 발생한다.

하지만 이렇게도 생각한다.
결국 사용자 시나리오이고, 모든 기능들을 연속적으로 사용한다고 생각하면,
즉 이후의 다른 기능들과 순서를 연계하여 db가 매번 초기화되지 않아도 동작하도록 만들면 그거대로 인수테스트의 역할을 하는 게 아닐까.

당장에는 그냥 같은 케이스의 다른 데이터를 사용하도록 처리하였다.

[REF: 테스트별로 db 초기화하기](https://velog.io/@junho5336/%ED%85%8C%EC%8A%A4%ED%8A%B8%EB%B3%84%EB%A1%9C-DB-%EC%B4%88%EA%B8%B0%ED%99%94%ED%95%98%EA%B8%B0)


## Checklist

-   [x] Does commit messages follow the convention?
-   [x] Are variable names brief but descriptive?
-   [x] Is the code clean and easy to understand?
-   [x] If a new feature has been added, or a bug fixed, has a test been added to confirm good behavior?
-   [x] Does the test successfully test edge and corner cases?

## 💬 Review Requirements (Optional)

Is there anything you can praise about this PR? Start with praise.
Make a review, leaving kind comments and suggesting changes where needed (to resolve the above).
