### PR TITLE
:sparkles: [FEAT] AccessToken 재발급 API 구현 

### DIFF
--- a/src/main/java/ac/dnd/dodal/application/user/service/AuthLoginService.java
+++ b/src/main/java/ac/dnd/dodal/application/user/service/AuthLoginService.java
@@ -27,13 +27,14 @@ import org.springframework.stereotype.Service;
 public class AuthLoginService {
 
   private final UserQueryUseCase userQueryUseCase;
+  private final AuthService authService;
   private final JwtUtil jwtUtil;
   private final OAuth2Util oAuth2Util;
   private final UserRepository userRepository;
 
   // 카카오 소셜 로그인
   public Object kakaoAuthSocialLogin(String token) {
-    String accessToken = AuthService.refineToken(token);
+    String accessToken = authService.refineToken(token);
 
     KakaoUserInfoDto kakaoUserInfoDto = getOAuth2UserInfo(accessToken);
 

--- a/src/main/java/ac/dnd/dodal/application/user/service/AuthService.java
+++ b/src/main/java/ac/dnd/dodal/application/user/service/AuthService.java
@@ -1,16 +1,49 @@
 package ac.dnd.dodal.application.user.service;
 
+import ac.dnd.dodal.application.user.usecase.UserQueryUseCase;
 import ac.dnd.dodal.common.constant.Constants;
+import ac.dnd.dodal.common.enums.CommonResultCode;
+import ac.dnd.dodal.common.exception.BadRequestException;
+import ac.dnd.dodal.core.security.enums.SecurityExceptionCode;
+import ac.dnd.dodal.core.security.util.JwtUtil;
+import ac.dnd.dodal.domain.user.enums.UserExceptionCode;
+import ac.dnd.dodal.domain.user.model.User;
+import ac.dnd.dodal.ui.auth.response.JwtTokenDto;
+import ac.dnd.dodal.ui.auth.response.UserInfoResponseDto;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional
 public class AuthService {
+
+  private final JwtUtil jwtUtil;
+  private final UserQueryUseCase userQueryUseCase;
 
   public static String refineToken(String accessToken) {
     return accessToken.startsWith(Constants.BEARER_PREFIX)
         ? accessToken.substring(Constants.BEARER_PREFIX.length())
         : accessToken;
+  }
+
+  public UserInfoResponseDto refresh(String token) {
+    String refreshToken = refineToken(token);
+
+    Long userId = jwtUtil.getUserIdFromToken(refreshToken);
+    User user = userQueryUseCase.findById(userId);
+
+    if (!user.getRefreshToken().equals(refreshToken)) {
+      throw new BadRequestException(SecurityExceptionCode.TOKEN_UNKNOWN_ERROR);
+    }
+
+    JwtTokenDto jwtTokenDto = jwtUtil.generateToken(user.getId(), user.getRole());
+    // 액세스 토큰을 다시 발급받을 때 refreshToken도 같이 업데이트 하여 장기간 접속하지 않는 한 로그인 유지
+    user.updateRefreshToken(jwtTokenDto.refreshToken());
+
+    return UserInfoResponseDto.fromUserEntity(user, jwtTokenDto);
   }
 }

--- a/src/main/java/ac/dnd/dodal/application/user/service/AuthService.java
+++ b/src/main/java/ac/dnd/dodal/application/user/service/AuthService.java
@@ -24,14 +24,14 @@ public class AuthService {
   private final JwtUtil jwtUtil;
   private final UserQueryUseCase userQueryUseCase;
 
-  public static String refineToken(String accessToken) {
+  public String refineToken(String accessToken) {
     return accessToken.startsWith(Constants.BEARER_PREFIX)
         ? accessToken.substring(Constants.BEARER_PREFIX.length())
         : accessToken;
   }
 
   public UserInfoResponseDto refresh(String token) {
-    String refreshToken = refineToken(token);
+    String refreshToken = this.refineToken(token);
 
     Long userId = jwtUtil.getUserIdFromToken(refreshToken);
     User user = userQueryUseCase.findById(userId);

--- a/src/main/java/ac/dnd/dodal/application/user/service/UserQueryService.java
+++ b/src/main/java/ac/dnd/dodal/application/user/service/UserQueryService.java
@@ -43,4 +43,10 @@ public class UserQueryService implements UserQueryUseCase {
                 .orElseThrow(() -> new UserNotFoundException(UserExceptionCode.NOT_FOUND_USER));
     }
 
+    @Override
+    public User findById(Long id) {
+        return userQueryRepository.findById(id)
+                .orElseThrow(() -> new UserNotFoundException(UserExceptionCode.NOT_FOUND_USER));
+    }
+
 }

--- a/src/main/java/ac/dnd/dodal/application/user/usecase/UserQueryUseCase.java
+++ b/src/main/java/ac/dnd/dodal/application/user/usecase/UserQueryUseCase.java
@@ -14,4 +14,6 @@ public interface UserQueryUseCase {
   void checkDuplicatedEmail(String email);
 
   User findByIdAndRole(Long id, UserRole userRole);
+
+  User findById(Long id);
 }

--- a/src/main/java/ac/dnd/dodal/ui/auth/AuthController.java
+++ b/src/main/java/ac/dnd/dodal/ui/auth/AuthController.java
@@ -1,6 +1,7 @@
 package ac.dnd.dodal.ui.auth;
 
 import ac.dnd.dodal.application.user.service.AuthLoginService;
+import ac.dnd.dodal.application.user.service.AuthService;
 import ac.dnd.dodal.application.user.service.AuthSignUpService;
 import ac.dnd.dodal.common.constant.Constants;
 import ac.dnd.dodal.common.response.ApiResponse;
@@ -20,6 +21,7 @@ public class AuthController {
 
   private final AuthLoginService authLoginService;
   private final AuthSignUpService authSignUpService;
+  private final AuthService authService;
 
   // 카카오 소셜 로그인
   @PostMapping("/login/kakao")
@@ -41,5 +43,12 @@ public class AuthController {
   public ApiResponse<?> authSignUp(
       @RequestBody @Valid OAuthUserInfoRequestDto authSignUpRequestDto) {
     return ApiResponse.success(authSignUpService.handleSignUp(authSignUpRequestDto));
+  }
+
+  // 액세스 토큰 재발급 및 리프레시 토큰 업데이트 API
+  @PostMapping("/refresh")
+  public ApiResponse<?> refresh(
+      @NotNull @RequestHeader(Constants.AUTHORIZATION_HEADER) String refreshToken) {
+    return ApiResponse.success(authService.refresh(refreshToken));
   }
 }

--- a/src/test/java/ac/dnd/dodal/AcceptanceTest.java
+++ b/src/test/java/ac/dnd/dodal/AcceptanceTest.java
@@ -17,6 +17,7 @@ public abstract class AcceptanceTest {
     protected static final int port = 9999;
 
     protected static final Long userId = 1L;
+    protected static final String userEmail = "test1@test.com";
     protected static final String accessToken = "eyJhbGciOiJIUzUxMiJ9.eyJ1aWQiOjEsInJvbGUiOiJVU0VSIiwiaWF0IjoxNzM5MzA4OTc1LCJleHAiOjE3NDAxODc4NTl9.7nH4G9T2PW9AI7JTCm7RteiechdLWsoeWanh4kX-Yt6UQ4qQVhohXlpA7DYR9fZZwjiyn7GLN73m1LXsNT1Djw";
     protected static final String refreshToken =
             "eyJhbGciOiJIUzUxMiJ9.eyJ1aWQiOjEsInJvbGUiOiJVU0VSIiwiaWF0IjoxNzM5MzA4OTc1LCJleHAiOjE3NDAxODc4NTl9.7nH4G9T2PW9AI7JTCm7RteiechdLWsoeWanh4kX-Yt6UQ4qQVhohXlpA7DYR9fZZwjiyn7GLN73m1LXsNT1Djw";

--- a/src/test/java/ac/dnd/dodal/acceptance/auth/refreshAccessTokenAcceptanceTest.java
+++ b/src/test/java/ac/dnd/dodal/acceptance/auth/refreshAccessTokenAcceptanceTest.java
@@ -1,0 +1,53 @@
+package ac.dnd.dodal.acceptance.auth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import ac.dnd.dodal.AcceptanceTest;
+import ac.dnd.dodal.acceptance.auth.steps.AuthSteps;
+import ac.dnd.dodal.common.enums.CommonResultCode;
+import ac.dnd.dodal.common.response.ApiResponse;
+import ac.dnd.dodal.core.security.enums.SecurityExceptionCode;
+import ac.dnd.dodal.ui.auth.response.JwtTokenDto;
+import ac.dnd.dodal.ui.auth.response.UserInfoResponseDto;
+import io.restassured.common.mapper.TypeRef;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+
+public class refreshAccessTokenAcceptanceTest extends AcceptanceTest {
+
+  @Test
+  @DisplayName("Refresh Access Token Test")
+  public void refresh_access_token() {
+    // when
+    Response response = AuthSteps.refreshAccessToken(refreshAuthorizationHeader);
+    ApiResponse<UserInfoResponseDto> apiResponse = response.as(new TypeRef<ApiResponse<UserInfoResponseDto>>() {});
+    UserInfoResponseDto userInfoResponseDto = apiResponse.data();
+    JwtTokenDto jwtTokenDto = userInfoResponseDto.jwtTokenDto();
+    // then 200
+    assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+    // COM001
+    assertThat(apiResponse.code()).isEqualTo(CommonResultCode.SUCCESS.getCode());
+    // Success
+    assertThat(apiResponse.message()).isEqualTo(CommonResultCode.SUCCESS.getMessage());
+    // data
+    assertThat(response.getBody().jsonPath().getMap("data").get("email")).isEqualTo(userEmail);
+  }
+
+  @Test
+  @DisplayName("Refresh Access Token Test with Unauthorized Refresh Token")
+    public void refresh_access_token_with_unauthorized_refresh_token() {
+        // when
+        Response response = AuthSteps.refreshAccessToken(unauthorizedRefreshAuthorizationHeader);
+        ApiResponse<UserInfoResponseDto> apiResponse = response.as(new TypeRef<ApiResponse<UserInfoResponseDto>>() {});
+        // then 401
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.UNAUTHORIZED.value());
+        // COM002
+        assertThat(apiResponse.code()).isEqualTo(SecurityExceptionCode.ACCESS_DENIED_ERROR.getCode());
+        // Unauthorized
+        assertThat(apiResponse.message()).isEqualTo(SecurityExceptionCode.ACCESS_DENIED_ERROR.getMessage());
+        // data does not exist
+        assertThat(response.getBody().jsonPath().getMap("data")).isNull();
+    }
+}

--- a/src/test/java/ac/dnd/dodal/acceptance/auth/refreshAccessTokenAcceptanceTest.java
+++ b/src/test/java/ac/dnd/dodal/acceptance/auth/refreshAccessTokenAcceptanceTest.java
@@ -33,6 +33,8 @@ public class refreshAccessTokenAcceptanceTest extends AcceptanceTest {
     assertThat(apiResponse.message()).isEqualTo(CommonResultCode.SUCCESS.getMessage());
     // data
     assertThat(response.getBody().jsonPath().getMap("data").get("email")).isEqualTo(userEmail);
+    assertThat(jwtTokenDto.accessToken()).isNotNull();
+    assertThat(jwtTokenDto.refreshToken()).isNotNull();
   }
 
   @Test

--- a/src/test/java/ac/dnd/dodal/acceptance/auth/steps/AuthSteps.java
+++ b/src/test/java/ac/dnd/dodal/acceptance/auth/steps/AuthSteps.java
@@ -1,0 +1,24 @@
+package ac.dnd.dodal.acceptance.auth.steps;
+
+import ac.dnd.dodal.AcceptanceTest;
+import io.restassured.response.Response;
+
+import java.util.Map;
+
+import static io.restassured.RestAssured.given;
+
+public class AuthSteps extends AcceptanceTest {
+
+    private static final String BASE_URL = "/api/auth";
+
+    public static Response refreshAccessToken(Map<String, Object> header) {
+        return given().log().all()
+                .headers(header)
+            .when()
+                .post(BASE_URL + "/refresh")
+            .then().log().all()
+                .extract()
+            .response();
+    }
+
+}

--- a/src/test/java/ac/dnd/dodal/ui/fixture/UIFixture.java
+++ b/src/test/java/ac/dnd/dodal/ui/fixture/UIFixture.java
@@ -9,7 +9,7 @@ public class UIFixture {
     }
 
     public static Map<String, Object> createRefreshAuthorizationHeader(String refreshToken) {
-        return Map.of("refreshToken", "Bearer " + refreshToken);
+        return Map.of("Authorization", "Bearer " + refreshToken);
     }
 
     public static Map<String, Object> createUnauthorizedHeader() {


### PR DESCRIPTION
## #️⃣ Related Issue

Linked Feature backlog: 

## 📝 Purpose of PR

Refresh 토큰을 사용하여 accessToken 재발급

## Contents

Refresh Token이 들어왔을 때 accessToken을 발급해주며, accessToken을 발급해줌과 동시에 refreshToken도 같이 갱신되도록 했습니다. 

## Checklist

-   [x] Does commit messages follow the convention?
-   [x] Are variable names brief but descriptive?
-   [x] Is the code clean and easy to understand?
-   [x] If a new feature has been added, or a bug fixed, has a test been added to confirm good behavior?
-   [x] Does the test successfully test edge and corner cases?

## 💬 Review Requirements (Optional)

Is there anything you can praise about this PR? Start with praise.
Make a review, leaving kind comments and suggesting changes where needed (to resolve the above).
