### PR TITLE
[FEAT] Get Plans of History

### DIFF
--- a/src/main/java/ac/dnd/dodal/application/feedback/repository/PlanFeedbackRepository.java
+++ b/src/main/java/ac/dnd/dodal/application/feedback/repository/PlanFeedbackRepository.java
@@ -1,9 +1,11 @@
 package ac.dnd.dodal.application.feedback.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
 import ac.dnd.dodal.domain.plan_feedback.model.PlanFeedback;
 import ac.dnd.dodal.domain.plan_feedback.model.PlanFeedbackId;
 
+@Repository
 public interface PlanFeedbackRepository extends JpaRepository<PlanFeedback, PlanFeedbackId> {
 }

--- a/src/main/java/ac/dnd/dodal/application/plan/dto/query/GetPlansOfHistoryQuery.java
+++ b/src/main/java/ac/dnd/dodal/application/plan/dto/query/GetPlansOfHistoryQuery.java
@@ -1,0 +1,11 @@
+package ac.dnd.dodal.application.plan.dto.query;
+
+import org.springframework.data.domain.Pageable;
+public record GetPlansOfHistoryQuery(
+    Long userId,
+    Long goalId,
+    Long historyId,
+    Pageable pageable
+) {
+    
+}

--- a/src/main/java/ac/dnd/dodal/application/plan/repository/PlanRepository.java
+++ b/src/main/java/ac/dnd/dodal/application/plan/repository/PlanRepository.java
@@ -5,12 +5,14 @@ import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 import ac.dnd.dodal.domain.plan.model.Plan;
 import ac.dnd.dodal.ui.plan.response.PlanElement;
 
+@Repository
 public interface PlanRepository extends JpaRepository<Plan, Long> {
 
     @Query("SELECT p FROM plans p WHERE p.history.historyId = :historyId "
@@ -27,8 +29,7 @@ public interface PlanRepository extends JpaRepository<Plan, Long> {
             + "AND history.deletedAt IS NULL "
             + "AND history.goal.goalId = :goalId "
             + "AND history.goal.deletedAt IS NULL "
-            + "AND history.goal.user.userId = :userId "
-            + "AND history.goal.user.deletedAt IS NULL")
+            + "AND history.goal.userId = :userId")
     boolean isExistByUserIdAndGoalIdAndHistoryId(
         @Param("userId") Long userId,
         @Param("goalId") Long goalId,

--- a/src/main/java/ac/dnd/dodal/application/plan/repository/PlanRepository.java
+++ b/src/main/java/ac/dnd/dodal/application/plan/repository/PlanRepository.java
@@ -5,12 +5,32 @@ import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 import ac.dnd.dodal.domain.plan.model.Plan;
+import ac.dnd.dodal.ui.plan.response.PlanElement;
 
 public interface PlanRepository extends JpaRepository<Plan, Long> {
 
-    @Query("SELECT p FROM plans p WHERE p.history.historyId = :historyId " + 
-        "ORDER BY p.endDate DESC LIMIT 1")
+    @Query("SELECT p FROM plans p WHERE p.history.historyId = :historyId "
+            + "ORDER BY p.endDate DESC LIMIT 1")
     Optional<Plan> findLatestPlanByHistoryId(@Param("historyId") Long historyId);
+
+    @Query("SELECT p FROM plans p WHERE p.history.historyId = :historyId "
+            + "AND p.deletedAt IS NULL AND p.completedDate IS NOT NULL "
+            + "ORDER BY p.completedDate DESC")
+    Page<PlanElement> findAllByHistoryId(@Param("historyId") Long historyId, Pageable pageable);
+
+    @Query("SELECT COUNT(history) > 0 FROM plan_histories history "
+            + "WHERE history.historyId = :historyId "
+            + "AND history.deletedAt IS NULL "
+            + "AND history.goal.goalId = :goalId "
+            + "AND history.goal.deletedAt IS NULL "
+            + "AND history.goal.user.userId = :userId "
+            + "AND history.goal.user.deletedAt IS NULL")
+    boolean isExistByUserIdAndGoalIdAndHistoryId(
+        @Param("userId") Long userId,
+        @Param("goalId") Long goalId,
+        @Param("historyId") Long historyId);
 }

--- a/src/main/java/ac/dnd/dodal/application/plan/service/PlanQueryService.java
+++ b/src/main/java/ac/dnd/dodal/application/plan/service/PlanQueryService.java
@@ -1,0 +1,21 @@
+package ac.dnd.dodal.application.plan.service;
+
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.stereotype.Service;
+import org.springframework.data.domain.Page;
+import ac.dnd.dodal.application.plan.repository.PlanRepository;
+import ac.dnd.dodal.application.plan.usecase.GetPlansOfHistoryUseCase;
+import ac.dnd.dodal.ui.plan.response.PlanElement;
+
+@Service
+@RequiredArgsConstructor
+public class PlanQueryService implements GetPlansOfHistoryUseCase {
+
+    private final PlanRepository planRepository;
+
+    @Override
+    public Page<PlanElement> getPlansOfHistory(Long userId, Long goalId, Long historyId) {
+        return null;
+    }
+}

--- a/src/main/java/ac/dnd/dodal/application/plan/service/PlanQueryService.java
+++ b/src/main/java/ac/dnd/dodal/application/plan/service/PlanQueryService.java
@@ -2,10 +2,13 @@ package ac.dnd.dodal.application.plan.service;
 
 import lombok.RequiredArgsConstructor;
 
-import org.springframework.stereotype.Service;
 import org.springframework.data.domain.Page;
+import org.springframework.stereotype.Service;
+
 import ac.dnd.dodal.application.plan.repository.PlanRepository;
 import ac.dnd.dodal.application.plan.usecase.GetPlansOfHistoryUseCase;
+import ac.dnd.dodal.common.exception.ForbiddenException;
+import ac.dnd.dodal.application.plan.dto.query.GetPlansOfHistoryQuery;
 import ac.dnd.dodal.ui.plan.response.PlanElement;
 
 @Service
@@ -15,7 +18,16 @@ public class PlanQueryService implements GetPlansOfHistoryUseCase {
     private final PlanRepository planRepository;
 
     @Override
-    public Page<PlanElement> getPlansOfHistory(Long userId, Long goalId, Long historyId) {
-        return null;
+    public Page<PlanElement> getPlansOfHistory(GetPlansOfHistoryQuery query) {
+        if (!isExistByUserIdAndGoalIdAndHistoryId(
+            query.userId(), query.goalId(), query.historyId())) {
+            throw new ForbiddenException();
+        }
+        return planRepository.findAllByHistoryId(query.historyId(), query.pageable());
+    }
+
+    public boolean isExistByUserIdAndGoalIdAndHistoryId(
+        Long userId, Long goalId, Long historyId) {
+        return planRepository.isExistByUserIdAndGoalIdAndHistoryId(userId, goalId, historyId);
     }
 }

--- a/src/main/java/ac/dnd/dodal/application/plan/usecase/GetPlansOfHistoryUseCase.java
+++ b/src/main/java/ac/dnd/dodal/application/plan/usecase/GetPlansOfHistoryUseCase.java
@@ -1,0 +1,9 @@
+package ac.dnd.dodal.application.plan.usecase;
+
+import org.springframework.data.domain.Page;
+import ac.dnd.dodal.ui.plan.response.PlanElement;
+
+public interface GetPlansOfHistoryUseCase {
+
+    Page<PlanElement> getPlansOfHistory(Long userId, Long goalId, Long historyId);
+}

--- a/src/main/java/ac/dnd/dodal/application/plan/usecase/GetPlansOfHistoryUseCase.java
+++ b/src/main/java/ac/dnd/dodal/application/plan/usecase/GetPlansOfHistoryUseCase.java
@@ -1,9 +1,11 @@
 package ac.dnd.dodal.application.plan.usecase;
 
 import org.springframework.data.domain.Page;
+
+import ac.dnd.dodal.application.plan.dto.query.GetPlansOfHistoryQuery;
 import ac.dnd.dodal.ui.plan.response.PlanElement;
 
 public interface GetPlansOfHistoryUseCase {
 
-    Page<PlanElement> getPlansOfHistory(Long userId, Long goalId, Long historyId);
+    Page<PlanElement> getPlansOfHistory(GetPlansOfHistoryQuery query);
 }

--- a/src/main/java/ac/dnd/dodal/application/plan_history/repository/PlanHistoryRepository.java
+++ b/src/main/java/ac/dnd/dodal/application/plan_history/repository/PlanHistoryRepository.java
@@ -1,9 +1,11 @@
 package ac.dnd.dodal.application.plan_history.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
 import ac.dnd.dodal.domain.plan_history.model.PlanHistory;
 
+@Repository
 public interface PlanHistoryRepository extends JpaRepository<PlanHistory, Long> {
     
 }

--- a/src/main/java/ac/dnd/dodal/common/response/ApiResponse.java
+++ b/src/main/java/ac/dnd/dodal/common/response/ApiResponse.java
@@ -41,11 +41,11 @@ public record ApiResponse<T>(
         );
     }
 
-    public static <T> ApiResponse<Page<T>> success(Page<T> data) {
+    public static <T> ApiResponse<PageResponse<T>> success(Page<T> data) {
         return new ApiResponse<>(
             CommonResultCode.SUCCESS.getCode(),
             CommonResultCode.SUCCESS.getMessage(),
-            data
+            new PageResponse<>(data)
         );
     }
 
@@ -58,10 +58,23 @@ public record ApiResponse<T>(
     }
 
     public static <T> ApiResponse<T> failure(ResultCode resultCode, String message) {
-        return new ApiResponse<>(
-            resultCode.getCode(),
-            message,
-            null
-        );
+        return new ApiResponse<>(resultCode.getCode(), message, null);
+    }
+
+    public record PageResponse<T>(
+        List<T> content,
+        int page,
+        int size,
+        boolean hasNext
+    ) {
+
+        public PageResponse(Page<T> page) {
+            this(
+                page.getContent(),
+                page.getNumber(),
+                page.getSize(),
+                page.hasNext()
+            );
+        }
     }
 }

--- a/src/main/java/ac/dnd/dodal/ui/plan/response/PlanElement.java
+++ b/src/main/java/ac/dnd/dodal/ui/plan/response/PlanElement.java
@@ -2,13 +2,12 @@ package ac.dnd.dodal.ui.plan.response;
 
 import java.time.LocalDateTime;
 
-import ac.dnd.dodal.domain.plan.enums.PlanStatus;
 import ac.dnd.dodal.domain.plan.model.Plan;
 
 public record PlanElement(
     Long planId,
     String title,
-    PlanStatus status,
+    String status,
     String guide,
     LocalDateTime completedDate
 ) {
@@ -17,7 +16,7 @@ public record PlanElement(
         return new PlanElement(
             plan.getPlanId(),
             plan.getTitle(),
-            plan.getStatus(),
+            plan.getStatus().getValue(),
             plan.getGuide(),
             plan.getCompletedDate()
         );

--- a/src/main/java/ac/dnd/dodal/ui/plan_history/PlanHistoryController.java
+++ b/src/main/java/ac/dnd/dodal/ui/plan_history/PlanHistoryController.java
@@ -1,0 +1,30 @@
+package ac.dnd.dodal.ui.plan_history;
+
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import ac.dnd.dodal.common.annotation.UserId;
+import ac.dnd.dodal.common.response.ApiResponse;
+import ac.dnd.dodal.common.response.ApiResponse.PageResponse;
+import ac.dnd.dodal.ui.plan.response.PlanElement;
+import ac.dnd.dodal.application.plan.usecase.GetPlansOfHistoryUseCase;
+
+@RestController
+@RequestMapping("/goals/{goalId}/plan-histories")
+@RequiredArgsConstructor
+public class PlanHistoryController {
+
+    private final GetPlansOfHistoryUseCase getPlansOfHistoryUseCase;
+
+    @GetMapping("/{historyId}")
+    public ApiResponse<PageResponse<PlanElement>> getPlansOfHistory(
+        @UserId Long userId,
+        @PathVariable Long goalId,
+        @PathVariable Long historyId) {
+        return ApiResponse.success(getPlansOfHistoryUseCase.getPlansOfHistory(userId, goalId, historyId));
+    }
+}

--- a/src/main/java/ac/dnd/dodal/ui/plan_history/PlanHistoryController.java
+++ b/src/main/java/ac/dnd/dodal/ui/plan_history/PlanHistoryController.java
@@ -6,12 +6,15 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.data.domain.PageRequest;
 
 import ac.dnd.dodal.common.annotation.UserId;
 import ac.dnd.dodal.common.response.ApiResponse;
 import ac.dnd.dodal.common.response.ApiResponse.PageResponse;
-import ac.dnd.dodal.ui.plan.response.PlanElement;
 import ac.dnd.dodal.application.plan.usecase.GetPlansOfHistoryUseCase;
+import ac.dnd.dodal.application.plan.dto.query.GetPlansOfHistoryQuery;
+import ac.dnd.dodal.ui.plan.response.PlanElement;
 
 @RestController
 @RequestMapping("/api/goals/{goalId}/plan-histories")
@@ -24,7 +27,12 @@ public class PlanHistoryController {
     public ApiResponse<PageResponse<PlanElement>> getPlansOfHistory(
         @UserId Long userId,
         @PathVariable Long goalId,
-        @PathVariable Long historyId) {
-        return ApiResponse.success(getPlansOfHistoryUseCase.getPlansOfHistory(userId, goalId, historyId));
+        @PathVariable Long historyId,
+        @RequestParam(required = false, defaultValue = "0") Integer page,
+        @RequestParam(required = false, defaultValue = "3") Integer size) {
+        GetPlansOfHistoryQuery query = new GetPlansOfHistoryQuery(
+            userId, goalId, historyId, PageRequest.of(page, size));
+
+        return ApiResponse.success(getPlansOfHistoryUseCase.getPlansOfHistory(query));
     }
 }

--- a/src/main/java/ac/dnd/dodal/ui/plan_history/PlanHistoryController.java
+++ b/src/main/java/ac/dnd/dodal/ui/plan_history/PlanHistoryController.java
@@ -14,7 +14,7 @@ import ac.dnd.dodal.ui.plan.response.PlanElement;
 import ac.dnd.dodal.application.plan.usecase.GetPlansOfHistoryUseCase;
 
 @RestController
-@RequestMapping("/goals/{goalId}/plan-histories")
+@RequestMapping("/api/goals/{goalId}/plan-histories")
 @RequiredArgsConstructor
 public class PlanHistoryController {
 

--- a/src/main/resources/db/migration/V100__add_completedDate_to_data.sql
+++ b/src/main/resources/db/migration/V100__add_completedDate_to_data.sql
@@ -1,0 +1,6 @@
+UPDATE plans
+SET completed_date = CASE
+    WHEN status = 'NONE' THEN NULL
+    WHEN status IN ('SUCCESS', 'FAILURE') THEN end_date
+    ELSE completed_date
+END;

--- a/src/test/java/ac/dnd/dodal/acceptance/goal/steps/GoalSteps.java
+++ b/src/test/java/ac/dnd/dodal/acceptance/goal/steps/GoalSteps.java
@@ -7,10 +7,9 @@ import static io.restassured.RestAssured.*;
 import io.restassured.response.Response;
 import io.restassured.http.ContentType;
 
-import ac.dnd.dodal.AcceptanceTest;
 import ac.dnd.dodal.ui.goal.request.CreateGoalRequest;
 
-public class GoalSteps extends AcceptanceTest {
+public class GoalSteps {
 
     private static final String BASE_URL = "/api/goals";
 

--- a/src/test/java/ac/dnd/dodal/acceptance/plan/steps/PlanSteps.java
+++ b/src/test/java/ac/dnd/dodal/acceptance/plan/steps/PlanSteps.java
@@ -7,10 +7,9 @@ import java.util.Map;
 import io.restassured.http.ContentType;
 import io.restassured.response.Response;
 
-import ac.dnd.dodal.AcceptanceTest;
 import ac.dnd.dodal.ui.feedback.request.CreateFeedbackRequest;
 
-public class PlanSteps extends AcceptanceTest {
+public class PlanSteps {
     
     private static final String COMPLETE_PLAN_URL = "/api/plans/{planId}/complete?status={status}";
 

--- a/src/test/java/ac/dnd/dodal/acceptance/plan_history/PlanHistoryAcceptenceTest.java
+++ b/src/test/java/ac/dnd/dodal/acceptance/plan_history/PlanHistoryAcceptenceTest.java
@@ -1,0 +1,42 @@
+package ac.dnd.dodal.acceptance.plan_history;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import lombok.extern.slf4j.Slf4j;
+
+import io.restassured.response.Response;
+import io.restassured.common.mapper.TypeRef;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.data.domain.Page;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import ac.dnd.dodal.AcceptanceTest;
+import ac.dnd.dodal.acceptance.plan_history.steps.GetPlansOfHistoryStep;
+import ac.dnd.dodal.common.response.ApiResponse;
+import ac.dnd.dodal.common.enums.CommonResultCode;
+import ac.dnd.dodal.ui.plan.response.PlanElement;
+
+@Slf4j
+public class PlanHistoryAcceptenceTest extends AcceptanceTest {
+
+    @Test
+    @DisplayName("get plan histories with pagination")
+    public void get_plan_histories() {
+        Response response = GetPlansOfHistoryStep
+            .getPlansOfHistory(authorizationHeader, goalId, planHistoryId);
+        ApiResponse<Page<PlanElement>> apiResponse =
+                response.as(new TypeRef<ApiResponse<Page<PlanElement>>>() {});
+
+        log.info("apiResponse: {}", apiResponse);
+        // then 200
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+        // COM001
+        assertThat(apiResponse.code()).isEqualTo(CommonResultCode.SUCCESS.getCode());
+        // Success
+        assertThat(apiResponse.message()).isEqualTo(CommonResultCode.SUCCESS.getMessage());
+        // size
+        assertThat(apiResponse.data().getContent().size()).isGreaterThan(0);
+    }
+}

--- a/src/test/java/ac/dnd/dodal/acceptance/plan_history/PlanHistoryAcceptenceTest.java
+++ b/src/test/java/ac/dnd/dodal/acceptance/plan_history/PlanHistoryAcceptenceTest.java
@@ -8,13 +8,13 @@ import io.restassured.response.Response;
 import io.restassured.common.mapper.TypeRef;
 
 import org.springframework.http.HttpStatus;
-import org.springframework.data.domain.Page;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import ac.dnd.dodal.AcceptanceTest;
 import ac.dnd.dodal.acceptance.plan_history.steps.GetPlansOfHistoryStep;
 import ac.dnd.dodal.common.response.ApiResponse;
+import ac.dnd.dodal.common.response.ApiResponse.PageResponse;
 import ac.dnd.dodal.common.enums.CommonResultCode;
 import ac.dnd.dodal.ui.plan.response.PlanElement;
 
@@ -26,8 +26,8 @@ public class PlanHistoryAcceptenceTest extends AcceptanceTest {
     public void get_plans_of_history() {
         Response response = GetPlansOfHistoryStep
             .getPlansOfHistory(authorizationHeader, goalId, planHistoryId);
-        ApiResponse<Page<PlanElement>> apiResponse =
-                response.as(new TypeRef<ApiResponse<Page<PlanElement>>>() {});
+        ApiResponse<PageResponse<PlanElement>> apiResponse =
+                response.as(new TypeRef<ApiResponse<PageResponse<PlanElement>>>() {});
 
         log.info("apiResponse: {}", apiResponse);
         // then 200
@@ -37,6 +37,6 @@ public class PlanHistoryAcceptenceTest extends AcceptanceTest {
         // Success
         assertThat(apiResponse.message()).isEqualTo(CommonResultCode.SUCCESS.getMessage());
         // size
-        assertThat(apiResponse.data().getContent().size()).isGreaterThan(0);
+        assertThat(apiResponse.data().content().size()).isGreaterThan(0);
     }
 }

--- a/src/test/java/ac/dnd/dodal/acceptance/plan_history/PlanHistoryAcceptenceTest.java
+++ b/src/test/java/ac/dnd/dodal/acceptance/plan_history/PlanHistoryAcceptenceTest.java
@@ -22,8 +22,8 @@ import ac.dnd.dodal.ui.plan.response.PlanElement;
 public class PlanHistoryAcceptenceTest extends AcceptanceTest {
 
     @Test
-    @DisplayName("get plan histories with pagination")
-    public void get_plan_histories() {
+    @DisplayName("get plans of history with pagination")
+    public void get_plans_of_history() {
         Response response = GetPlansOfHistoryStep
             .getPlansOfHistory(authorizationHeader, goalId, planHistoryId);
         ApiResponse<Page<PlanElement>> apiResponse =

--- a/src/test/java/ac/dnd/dodal/acceptance/plan_history/steps/GetPlansOfHistoryStep.java
+++ b/src/test/java/ac/dnd/dodal/acceptance/plan_history/steps/GetPlansOfHistoryStep.java
@@ -1,0 +1,29 @@
+package ac.dnd.dodal.acceptance.plan_history.steps;
+
+import static io.restassured.RestAssured.given;
+
+import java.util.Map;
+
+import io.restassured.response.Response;
+import io.restassured.http.ContentType;
+
+
+public class GetPlansOfHistoryStep {
+
+    private static final String BASE_URL = "/api/goals/{goalId}/plan-histories/{historyId}";
+
+    public static Response getPlansOfHistory(
+            Map<String, Object> header, Long goalId, Long historyId) {
+        String url = BASE_URL.replace("{goalId}", goalId.toString())
+                .replace("{historyId}", historyId.toString());
+
+        return given().log().all()
+                .contentType(ContentType.JSON)
+                .headers(header)
+            .when()
+                .get(url)
+            .then().log().all()
+                .extract()
+            .response();
+    }
+}


### PR DESCRIPTION
## #️⃣ Related Issue

Linked Feature backlog: close #35 close #36 

## 📝 Purpose of PR

히스토리 내의 완료 계획들을 조회한다.

## Contents

- goal / history가 삭제되었을 경우 forbiddenexception

### Issue: QueryService?
실은 query로 가져오는 것은 controller에서 바로 가져와도 상관이 없다. 로직이랄 게 없으니.
다만 여기서 goal, history 등이 deleted 되었을 경우 예외를 던진다는 로직이 존재하기 때문에 따로 서비스를 두었다.

### Issue: 어디 패키지에 속하는 게 옳을까
request url은 goal, history 둘 다 갖고
plan history에도 해당하며, 결국 조회하는 것은 plan이다.
planQuery로 두는 것은 이견이 없어 planQuerySerivce에 두었다.
추구 planQueryRepository가 분리되면 (QueryDSL과 함께) 그때는 나누는 게 유의미해질 듯 하다.

### Issue: QueryDSL

쿼리가 복잡해지고, 쿼리에 대해 컴파일 시에 에러를 잡기 위해 queryDSL 도입을 시도했다.
하지만 의존성 처리 과정에서 에러가 발생하여 build 자체가 되지 않아 철회함
추후 추가해보자

## Checklist

-   [x] Does commit messages follow the convention?
-   [x] Are variable names brief but descriptive?
-   [x] Is the code clean and easy to understand?
-   [x] If a new feature has been added, or a bug fixed, has a test been added to confirm good behavior?
-   [ ] Does the test successfully test edge and corner cases?

## 💬 Review Requirements (Optional)

Is there anything you can praise about this PR? Start with praise.
Make a review, leaving kind comments and suggesting changes where needed (to resolve the above).
