### PR TITLE
[FEAT] 온보딩 관련 데이터 조회 기능 구현 

### DIFF
--- a/src/main/java/ac/dnd/dodal/application/onboarding/repository/AnswerRepository.java
+++ b/src/main/java/ac/dnd/dodal/application/onboarding/repository/AnswerRepository.java
@@ -1,0 +1,15 @@
+package ac.dnd.dodal.application.onboarding.repository;
+
+import ac.dnd.dodal.domain.onboarding.model.Answer;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface AnswerRepository extends JpaRepository<Answer, Long> {
+
+    @Query("SELECT a FROM Answer a WHERE a.question.id IN :questionIds")
+    List<Answer> findAllByQuestionId(
+            @Param("questionIds") List<Long> questionIds);
+}

--- a/src/main/java/ac/dnd/dodal/application/onboarding/repository/QuestionRepository.java
+++ b/src/main/java/ac/dnd/dodal/application/onboarding/repository/QuestionRepository.java
@@ -1,0 +1,15 @@
+package ac.dnd.dodal.application.onboarding.repository;
+
+import ac.dnd.dodal.domain.onboarding.model.Question;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface QuestionRepository extends JpaRepository<Question, Long> {
+
+    @Query("SELECT q FROM Question q ORDER BY q.order ASC")
+    List<Question> findAllByOrderAsc();
+}

--- a/src/main/java/ac/dnd/dodal/application/onboarding/service/OnBoardingService.java
+++ b/src/main/java/ac/dnd/dodal/application/onboarding/service/OnBoardingService.java
@@ -1,0 +1,52 @@
+package ac.dnd.dodal.application.onboarding.service;
+
+import ac.dnd.dodal.application.onboarding.repository.AnswerRepository;
+import ac.dnd.dodal.application.onboarding.repository.QuestionRepository;
+import ac.dnd.dodal.application.onboarding.usecase.GetQuestionsAndAnswersUseCase;
+import ac.dnd.dodal.domain.onboarding.model.Answer;
+import ac.dnd.dodal.domain.onboarding.model.Question;
+import ac.dnd.dodal.ui.onboarding.response.GetOnBoardingResponseDto;
+import jakarta.transaction.Transactional;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class OnBoardingService implements GetQuestionsAndAnswersUseCase {
+
+    private final QuestionRepository questionRepository;
+    private final AnswerRepository answerRepository;
+
+    @Override
+    public List<GetOnBoardingResponseDto> getQuestionsAndAnswers() {
+        List<Question> questions = getQuestions();
+        Map<Long, List<Answer>> answers = getAnswers(questions);
+        return mapQuestionAndAnswerToResponseDto(questions, answers);
+    }
+
+    private List<Question> getQuestions(){
+        return questionRepository.findAllByOrderAsc();
+    }
+
+    private Map<Long, List<Answer>> getAnswers(List<Question> questions){
+        return answerRepository.findAllByQuestionId(questions.stream().map(Question::getId).collect(Collectors.toList())).stream()
+                .collect(Collectors.groupingBy(answer -> answer.getQuestion().getId()));
+    }
+
+    private List<GetOnBoardingResponseDto> mapQuestionAndAnswerToResponseDto(List<Question> questions, Map<Long, List<Answer>> answers){
+        return questions.stream()
+                .map(question -> GetOnBoardingResponseDto.of(
+                        question,
+                        answers.getOrDefault(question.getId(), Collections.emptyList())
+                ))
+                .collect(Collectors.toList());
+    }
+
+}

--- a/src/main/java/ac/dnd/dodal/application/onboarding/usecase/GetQuestionsAndAnswersUseCase.java
+++ b/src/main/java/ac/dnd/dodal/application/onboarding/usecase/GetQuestionsAndAnswersUseCase.java
@@ -1,0 +1,10 @@
+package ac.dnd.dodal.application.onboarding.usecase;
+
+import ac.dnd.dodal.ui.onboarding.response.GetOnBoardingResponseDto;
+
+import java.util.List;
+
+public interface GetQuestionsAndAnswersUseCase {
+
+    List<GetOnBoardingResponseDto> getQuestionsAndAnswers();
+}

--- a/src/main/java/ac/dnd/dodal/ui/onboarding/OnBoardingController.java
+++ b/src/main/java/ac/dnd/dodal/ui/onboarding/OnBoardingController.java
@@ -1,0 +1,26 @@
+package ac.dnd.dodal.ui.onboarding;
+
+import ac.dnd.dodal.application.onboarding.usecase.GetQuestionsAndAnswersUseCase;
+import ac.dnd.dodal.common.response.ApiResponse;
+import ac.dnd.dodal.ui.onboarding.response.GetOnBoardingResponseDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/onboarding")
+public class OnBoardingController {
+
+    private final GetQuestionsAndAnswersUseCase getQuestionsAndAnswersUseCase;
+
+    @GetMapping("")
+    public ApiResponse<List<GetOnBoardingResponseDto>> getOnboardingQuestionAndAnswer(){
+        return ApiResponse.success(getQuestionsAndAnswersUseCase.getQuestionsAndAnswers());
+    }
+}

--- a/src/main/java/ac/dnd/dodal/ui/onboarding/OnBoardingController.java
+++ b/src/main/java/ac/dnd/dodal/ui/onboarding/OnBoardingController.java
@@ -19,7 +19,7 @@ public class OnBoardingController {
 
     private final GetQuestionsAndAnswersUseCase getQuestionsAndAnswersUseCase;
 
-    @GetMapping("")
+    @GetMapping
     public ApiResponse<List<GetOnBoardingResponseDto>> getOnboardingQuestionAndAnswer(){
         return ApiResponse.success(getQuestionsAndAnswersUseCase.getQuestionsAndAnswers());
     }

--- a/src/main/java/ac/dnd/dodal/ui/onboarding/response/AnswerResponseDto.java
+++ b/src/main/java/ac/dnd/dodal/ui/onboarding/response/AnswerResponseDto.java
@@ -1,0 +1,13 @@
+package ac.dnd.dodal.ui.onboarding.response;
+
+import ac.dnd.dodal.domain.onboarding.model.Answer;
+
+public record AnswerResponseDto(
+        Long answerId,
+        String content
+) {
+
+    public static AnswerResponseDto of(Answer answer) {
+        return new AnswerResponseDto(answer.getAnswerId(), answer.getContent().getContent());
+    }
+}

--- a/src/main/java/ac/dnd/dodal/ui/onboarding/response/GetOnBoardingResponseDto.java
+++ b/src/main/java/ac/dnd/dodal/ui/onboarding/response/GetOnBoardingResponseDto.java
@@ -1,23 +1,23 @@
 package ac.dnd.dodal.ui.onboarding.response;
 
-import ac.dnd.dodal.domain.onboarding.enums.AnswerContent;
 import ac.dnd.dodal.domain.onboarding.model.Answer;
 import ac.dnd.dodal.domain.onboarding.model.Question;
-
 import java.util.List;
 
 public record GetOnBoardingResponseDto(
-        String question,
+        Long questionId,
+        String questionContent,
         String subContent,
         int order,
-        List<String> answers
+        List<AnswerResponseDto> answers
 ) {
+
     public static GetOnBoardingResponseDto of(Question question, List<Answer> answers) {
         return new GetOnBoardingResponseDto(
+                question.getId(),
                 question.getQuestionContent().getMainContent(),
                 question.getQuestionContent().getSubContent(),
                 question.getOrder(),
-                answers.stream().map(Answer::getContent).map(AnswerContent::getContent).toList()
-        );
+                answers.stream().map(AnswerResponseDto::of).toList());
     }
 }

--- a/src/main/java/ac/dnd/dodal/ui/onboarding/response/GetOnBoardingResponseDto.java
+++ b/src/main/java/ac/dnd/dodal/ui/onboarding/response/GetOnBoardingResponseDto.java
@@ -1,0 +1,23 @@
+package ac.dnd.dodal.ui.onboarding.response;
+
+import ac.dnd.dodal.domain.onboarding.enums.AnswerContent;
+import ac.dnd.dodal.domain.onboarding.model.Answer;
+import ac.dnd.dodal.domain.onboarding.model.Question;
+
+import java.util.List;
+
+public record GetOnBoardingResponseDto(
+        String question,
+        String subContent,
+        int order,
+        List<String> answers
+) {
+    public static GetOnBoardingResponseDto of(Question question, List<Answer> answers) {
+        return new GetOnBoardingResponseDto(
+                question.getQuestionContent().getMainContent(),
+                question.getQuestionContent().getSubContent(),
+                question.getOrder(),
+                answers.stream().map(Answer::getContent).map(AnswerContent::getContent).toList()
+        );
+    }
+}

--- a/src/test/java/ac/dnd/dodal/acceptance/onboarding/GetOnBoardingDataAcceptanceTest.java
+++ b/src/test/java/ac/dnd/dodal/acceptance/onboarding/GetOnBoardingDataAcceptanceTest.java
@@ -1,0 +1,56 @@
+package ac.dnd.dodal.acceptance.onboarding;
+
+import ac.dnd.dodal.AcceptanceTest;
+import ac.dnd.dodal.acceptance.onboarding.steps.OnBoardingSteps;
+import ac.dnd.dodal.common.enums.CommonResultCode;
+import ac.dnd.dodal.common.response.ApiResponse;
+import ac.dnd.dodal.core.security.enums.SecurityExceptionCode;
+import ac.dnd.dodal.ui.onboarding.response.GetOnBoardingResponseDto;
+import io.restassured.common.mapper.TypeRef;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class GetOnBoardingDataAcceptanceTest extends AcceptanceTest {
+
+    @Test
+    @DisplayName("온보딩 데이터를 조회한다.")
+    public void getOnboardingData() {
+        // when
+        Response response = OnBoardingSteps.getQuestionsAndAnswers(authorizationHeader);
+        ApiResponse<List<GetOnBoardingResponseDto>> apiResponse = response.as(new TypeRef<ApiResponse<List<GetOnBoardingResponseDto>>>() {});
+
+        // then 200
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+        // COM001
+        assertThat(apiResponse.code()).isEqualTo(CommonResultCode.SUCCESS.getCode());
+        // Success
+        assertThat(apiResponse.message()).isEqualTo(CommonResultCode.SUCCESS.getMessage());
+        // data exist
+        assertThat(apiResponse.data().get(0)).isNotNull();
+    }
+
+    @Test
+    @DisplayName("온보딩 데이터를 조회 실패한다.")
+    public void getFailOnboardingData() {
+        // when
+        Response response = OnBoardingSteps.getQuestionsAndAnswers(unauthorizedAuthorizationHeader);
+        ApiResponse<List<GetOnBoardingResponseDto>> apiResponse =
+                response.as(new TypeRef<ApiResponse<List<GetOnBoardingResponseDto>>>() {});
+
+        // then 403
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.UNAUTHORIZED.value());
+        // SEC009
+        assertThat(apiResponse.code()).isEqualTo(SecurityExceptionCode.ACCESS_DENIED_ERROR.getCode());
+        // Fail
+        assertThat(apiResponse.message())
+                .isEqualTo(SecurityExceptionCode.ACCESS_DENIED_ERROR.getMessage());
+        // data exist
+        assertThat(apiResponse.data()).isNull();
+    }
+}

--- a/src/test/java/ac/dnd/dodal/acceptance/onboarding/steps/OnBoardingSteps.java
+++ b/src/test/java/ac/dnd/dodal/acceptance/onboarding/steps/OnBoardingSteps.java
@@ -1,0 +1,35 @@
+package ac.dnd.dodal.acceptance.onboarding.steps;
+
+import io.restassured.response.Response;
+
+import java.util.Map;
+
+import static io.restassured.RestAssured.given;
+
+public class OnBoardingSteps {
+
+    private static final String BASE_URL = "/api/onboarding";
+
+    public static Response getQuestionsAndAnswers(Map<String, Object> header) {
+        return given().log().all()
+                .headers(header)
+                .when()
+                .get(BASE_URL)
+                .then().log().all()
+                .extract()
+                .response();
+    }
+
+    public static Response addUserAnswers(Map<String, Object> header, Map<String, Object> body) {
+        return given().log().all()
+                .contentType("application/json")
+                .headers(header)
+                .body(body)
+                .when()
+                .post(BASE_URL)
+                .then().log().all()
+                .extract()
+                .response();
+    }
+
+}


### PR DESCRIPTION
## #️⃣ Related Issue

Linked Feature backlog: #53 

## 📝 Purpose of PR

온보딩 관련 데이터를 조회할 수 있는 기능 구현 

## Contents

온보딩 시 질문, 보조글, 선택 가능한 답변 목록을 서버로부터 내려받을 수 있도록 했습니다. 
서버에서 내려받아야 후에 데이터가 추가되었을 경우에 서버에서 데이터를 추가하는 방식으로 구현할 수 있고, 클라이언트는 변경사항 없이 그대로 사용이 가능하기 때문입니다. 

온보딩 엔티티 추가 코드가 먼저 main 브랜치에 머지된 후에 머지해야 합니다.

## Checklist

-   [ ] Does commit messages follow the convention?
-   [ ] Are variable names brief but descriptive?
-   [ ] Is the code clean and easy to understand?
-   [ ] If a new feature has been added, or a bug fixed, has a test been added to confirm good behavior?
-   [ ] Does the test successfully test edge and corner cases?

## 💬 Review Requirements (Optional)

Is there anything you can praise about this PR? Start with praise.
Make a review, leaving kind comments and suggesting changes where needed (to resolve the above).
