### PR TITLE
[REFACTOR] 회원 탈퇴 시 관련 엔티티 삭제 

### DIFF
--- a/src/main/java/ac/dnd/dodal/application/goal/dto/command/DeleteAllGoalCommand.java
+++ b/src/main/java/ac/dnd/dodal/application/goal/dto/command/DeleteAllGoalCommand.java
@@ -1,0 +1,7 @@
+package ac.dnd.dodal.application.goal.dto.command;
+
+public record DeleteAllGoalCommand(
+        Long userId
+) {
+
+}

--- a/src/main/java/ac/dnd/dodal/application/goal/repository/GoalRepository.java
+++ b/src/main/java/ac/dnd/dodal/application/goal/repository/GoalRepository.java
@@ -42,4 +42,7 @@ public interface GoalRepository extends JpaRepository<Goal, Long> {
     + "ORDER BY g.updatedAt DESC")
     List<GoalStatisticsResponse> findAchievedGoalStatisticsResponsesByUserId(
         @Param("userId") Long userId);
+
+    @Query("SELECT g FROM goals g WHERE g.userId = :userId AND g.deletedAt IS NULL")
+    List<Goal> findAllByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/ac/dnd/dodal/application/goal/service/GoalCommandService.java
+++ b/src/main/java/ac/dnd/dodal/application/goal/service/GoalCommandService.java
@@ -14,6 +14,8 @@ import ac.dnd.dodal.application.goal.usecase.CreateGoalUseCase;
 import ac.dnd.dodal.application.goal.usecase.AchieveGoalUseCase;
 import ac.dnd.dodal.application.goal.usecase.DeleteGoalUseCase;
 
+import java.util.List;
+
 @Service
 @Transactional
 @RequiredArgsConstructor
@@ -56,5 +58,11 @@ public class GoalCommandService
         goal.delete(command.userId());
 
         goalService.save(goal);
+    }
+
+    public void deleteAll(DeleteAllGoalCommand command) {
+        List<Goal> goals = goalService.findAllByUserId(command.userId());
+        goals.forEach(goal -> goal.delete(command.userId()));
+        goalService.saveAll(goals);
     }
 }

--- a/src/main/java/ac/dnd/dodal/application/goal/service/GoalCommandService.java
+++ b/src/main/java/ac/dnd/dodal/application/goal/service/GoalCommandService.java
@@ -1,6 +1,7 @@
 package ac.dnd.dodal.application.goal.service;
 
 import ac.dnd.dodal.application.goal.usecase.UpdateGoalUseCase;
+import ac.dnd.dodal.domain.goal.event.DeletedGoalEvent;
 import lombok.RequiredArgsConstructor;
 
 import org.springframework.stereotype.Service;
@@ -62,7 +63,12 @@ public class GoalCommandService
 
     public void deleteAll(DeleteAllGoalCommand command) {
         List<Goal> goals = goalService.findAllByUserId(command.userId());
-        goals.forEach(goal -> goal.delete(command.userId()));
+        goals
+                .forEach(goal -> {
+                    goal.delete(command.userId());
+                    eventPublisher.publishEvent(new DeletedGoalEvent(goal.getGoalId()));
+                });
+
         goalService.saveAll(goals);
     }
 }

--- a/src/main/java/ac/dnd/dodal/application/goal/service/GoalEventListener.java
+++ b/src/main/java/ac/dnd/dodal/application/goal/service/GoalEventListener.java
@@ -2,14 +2,12 @@ package ac.dnd.dodal.application.goal.service;
 
 import ac.dnd.dodal.application.goal.dto.command.DeleteAllGoalCommand;
 import ac.dnd.dodal.domain.user.event.UserWithdrawnEvent;
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.event.EventListener;
-import org.springframework.stereotype.Service;
+import org.springframework.stereotype.Component;
 
-@Service
+@Component
 @RequiredArgsConstructor
-@Transactional
 public class GoalEventListener {
 
     private final GoalCommandService goalCommandService;

--- a/src/main/java/ac/dnd/dodal/application/goal/service/GoalEventListener.java
+++ b/src/main/java/ac/dnd/dodal/application/goal/service/GoalEventListener.java
@@ -1,0 +1,21 @@
+package ac.dnd.dodal.application.goal.service;
+
+import ac.dnd.dodal.application.goal.dto.command.DeleteAllGoalCommand;
+import ac.dnd.dodal.domain.user.event.UserWithdrawnEvent;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class GoalEventListener {
+
+    private final GoalCommandService goalCommandService;
+
+    @EventListener
+    public void handleUserWithdrawnEvent(UserWithdrawnEvent event) {
+        goalCommandService.deleteAll(new DeleteAllGoalCommand(event.getUserId()));
+    }
+}

--- a/src/main/java/ac/dnd/dodal/application/goal/service/GoalEventListener.java
+++ b/src/main/java/ac/dnd/dodal/application/goal/service/GoalEventListener.java
@@ -4,6 +4,7 @@ import ac.dnd.dodal.application.goal.dto.command.DeleteAllGoalCommand;
 import ac.dnd.dodal.domain.user.event.UserWithdrawnEvent;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -12,6 +13,7 @@ public class GoalEventListener {
 
     private final GoalCommandService goalCommandService;
 
+    @Async
     @EventListener
     public void handleUserWithdrawnEvent(UserWithdrawnEvent event) {
         goalCommandService.deleteAll(new DeleteAllGoalCommand(event.getUserId()));

--- a/src/main/java/ac/dnd/dodal/application/goal/service/GoalService.java
+++ b/src/main/java/ac/dnd/dodal/application/goal/service/GoalService.java
@@ -1,6 +1,8 @@
 package ac.dnd.dodal.application.goal.service;
 
 import lombok.RequiredArgsConstructor;
+
+import java.util.List;
 import java.util.Optional;
 import org.springframework.stereotype.Service;
 
@@ -19,6 +21,10 @@ public class GoalService {
         return goalRepository.save(goal);
     }
 
+    public List<Goal> saveAll(List<Goal> goals) {
+        return goalRepository.saveAll(goals);
+    }
+
     public Goal saveAndFlush(Goal goal) {
         return goalRepository.saveAndFlush(goal);
     }
@@ -30,5 +36,9 @@ public class GoalService {
     public Goal findByIdOrThrow(Long goalId) {
         return goalRepository.findById(goalId)
                 .orElseThrow(() -> new NotFoundException(GoalExceptionCode.GOAL_NOT_FOUND));
+    }
+
+    public List<Goal> findAllByUserId(Long userId) {
+        return goalRepository.findAllByUserId(userId);
     }
 }

--- a/src/main/java/ac/dnd/dodal/application/goal/service/GoalStatisticsEventListener.java
+++ b/src/main/java/ac/dnd/dodal/application/goal/service/GoalStatisticsEventListener.java
@@ -1,15 +1,12 @@
 package ac.dnd.dodal.application.goal.service;
 
 import ac.dnd.dodal.domain.goal.event.DeletedGoalEvent;
-import ac.dnd.dodal.domain.user.event.UserWithdrawnEvent;
+import ac.dnd.dodal.domain.goal.event.GoalCreatedEvent;
+import ac.dnd.dodal.domain.goal.model.GoalStatistics;
+import ac.dnd.dodal.domain.plan.event.PlanCompletedEvent;
 import lombok.RequiredArgsConstructor;
-
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
-
-import ac.dnd.dodal.domain.goal.model.GoalStatistics;
-import ac.dnd.dodal.domain.goal.event.GoalCreatedEvent;
-import ac.dnd.dodal.domain.plan.event.PlanCompletedEvent;
 
 @Component
 @RequiredArgsConstructor

--- a/src/main/java/ac/dnd/dodal/application/goal/service/GoalStatisticsEventListener.java
+++ b/src/main/java/ac/dnd/dodal/application/goal/service/GoalStatisticsEventListener.java
@@ -6,6 +6,7 @@ import ac.dnd.dodal.domain.goal.model.GoalStatistics;
 import ac.dnd.dodal.domain.plan.event.PlanCompletedEvent;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -29,6 +30,7 @@ public class GoalStatisticsEventListener {
         goalStatisticsService.save(goalStatistics);
     }
 
+    @Async
     @EventListener
     public void handleDeletedGoalEvent(DeletedGoalEvent event) {
         goalStatisticsService.delete(event.getGoalId());

--- a/src/main/java/ac/dnd/dodal/application/goal/service/GoalStatisticsEventListener.java
+++ b/src/main/java/ac/dnd/dodal/application/goal/service/GoalStatisticsEventListener.java
@@ -1,5 +1,7 @@
 package ac.dnd.dodal.application.goal.service;
 
+import ac.dnd.dodal.domain.goal.event.DeletedGoalEvent;
+import ac.dnd.dodal.domain.user.event.UserWithdrawnEvent;
 import lombok.RequiredArgsConstructor;
 
 import org.springframework.context.event.EventListener;
@@ -28,5 +30,10 @@ public class GoalStatisticsEventListener {
 
         goalStatistics.incrementCount(event.getStatus());
         goalStatisticsService.save(goalStatistics);
+    }
+
+    @EventListener
+    public void handleDeletedGoalEvent(DeletedGoalEvent event) {
+        goalStatisticsService.delete(event.getGoalId());
     }
 }

--- a/src/main/java/ac/dnd/dodal/application/goal/service/GoalStatisticsService.java
+++ b/src/main/java/ac/dnd/dodal/application/goal/service/GoalStatisticsService.java
@@ -38,4 +38,8 @@ public class GoalStatisticsService implements GetGoalSuccessRateUseCase {
 
         return GoalStatisticsResponse.of(goalStatistics);
     }
+
+    public void delete(Long goalId) {
+        goalStatisticsRepository.deleteById(goalId);
+    }
 }

--- a/src/main/java/ac/dnd/dodal/application/plan/dto/command/DeleteAllPlanCommand.java
+++ b/src/main/java/ac/dnd/dodal/application/plan/dto/command/DeleteAllPlanCommand.java
@@ -1,0 +1,11 @@
+package ac.dnd.dodal.application.plan.dto.command;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class DeleteAllPlanCommand {
+
+    private Long goalId;
+}

--- a/src/main/java/ac/dnd/dodal/application/plan/repository/PlanRepository.java
+++ b/src/main/java/ac/dnd/dodal/application/plan/repository/PlanRepository.java
@@ -52,6 +52,9 @@ public interface PlanRepository extends JpaRepository<Plan, Long> {
             + "AND p.deletedAt IS NULL ")
     List<Plan> findAllByGoalId(Long goalId);
 
+    @Query("SELECT p FROM plans p where p.goal.goalId = :goalId ")
+    List<Plan> findAllDeletedPlanByGoalId(Long goalId);
+
     @Query("SELECT COUNT(history) > 0 FROM plan_histories history "
             + "WHERE history.historyId = :historyId "
             + "AND history.deletedAt IS NULL "

--- a/src/main/java/ac/dnd/dodal/application/plan/repository/PlanRepository.java
+++ b/src/main/java/ac/dnd/dodal/application/plan/repository/PlanRepository.java
@@ -48,6 +48,10 @@ public interface PlanRepository extends JpaRepository<Plan, Long> {
         @Param("startDate") LocalDateTime startDate,
         @Param("endDate") LocalDateTime endDate);
 
+    @Query("SELECT p FROM plans p where p.goal.goalId = :goalId "
+            + "AND p.deletedAt IS NULL ")
+    List<Plan> findAllByGoalId(Long goalId);
+
     @Query("SELECT COUNT(history) > 0 FROM plan_histories history "
             + "WHERE history.historyId = :historyId "
             + "AND history.deletedAt IS NULL "

--- a/src/main/java/ac/dnd/dodal/application/plan/service/PlanCommandService.java
+++ b/src/main/java/ac/dnd/dodal/application/plan/service/PlanCommandService.java
@@ -128,8 +128,22 @@ public class PlanCommandService implements
                 new DeletedPlanEvent(
                         plan.getPlanId(),
                         plan.getHistory().getHistoryId(), 
-                        command.userId(), 
                         plan.getStatus()));
+    }
+
+    public void deleteAllByGoalId(DeleteAllPlanCommand command) {
+        List<Plan> plans = planService.findAllByGoalId(command.getGoalId());
+        plans.forEach(plan -> {
+            plan.delete();
+            eventPublisher.publishEvent(
+                    new DeletedPlanEvent(
+                            plan.getPlanId(),
+                            plan.getHistory().getHistoryId(),
+                            plan.getStatus()
+                    )
+            );
+        });
+        planService.saveAll(plans);
     }
 
     private List<Plan> generateIterationPlans(AddSamePlanCommand command, Plan plan) {

--- a/src/main/java/ac/dnd/dodal/application/plan/service/PlanEventListener.java
+++ b/src/main/java/ac/dnd/dodal/application/plan/service/PlanEventListener.java
@@ -1,0 +1,19 @@
+package ac.dnd.dodal.application.plan.service;
+
+import ac.dnd.dodal.application.plan.dto.command.DeleteAllPlanCommand;
+import ac.dnd.dodal.domain.goal.event.DeletedGoalEvent;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class PlanEventListener {
+
+    private final PlanCommandService planCommandService;
+
+    @EventListener
+    public void handleDeletedGoalEvent(DeletedGoalEvent event) {
+    planCommandService.deleteAllByGoalId(new DeleteAllPlanCommand(event.getGoalId()));
+    }
+}

--- a/src/main/java/ac/dnd/dodal/application/plan/service/PlanEventListener.java
+++ b/src/main/java/ac/dnd/dodal/application/plan/service/PlanEventListener.java
@@ -4,6 +4,7 @@ import ac.dnd.dodal.application.plan.dto.command.DeleteAllPlanCommand;
 import ac.dnd.dodal.domain.goal.event.DeletedGoalEvent;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -12,6 +13,7 @@ public class PlanEventListener {
 
     private final PlanCommandService planCommandService;
 
+    @Async
     @EventListener
     public void handleDeletedGoalEvent(DeletedGoalEvent event) {
     planCommandService.deleteAllByGoalId(new DeleteAllPlanCommand(event.getGoalId()));

--- a/src/main/java/ac/dnd/dodal/application/plan/service/PlanService.java
+++ b/src/main/java/ac/dnd/dodal/application/plan/service/PlanService.java
@@ -34,6 +34,10 @@ public class PlanService {
         return planRepository.findById(planId);
     }
 
+    public List<Plan> findAllByGoalId(Long goalId) {
+        return planRepository.findAllByGoalId(goalId);
+    }
+
     public Plan findByIdOrThrow(Long planId) {
         return planRepository.findById(planId)
                 .orElseThrow(() -> new NotFoundException(PlanExceptionCode.PLAN_NOT_FOUND));

--- a/src/main/java/ac/dnd/dodal/application/plan_feedback/dto/command/DeleteAllPlanFeedbackCommand.java
+++ b/src/main/java/ac/dnd/dodal/application/plan_feedback/dto/command/DeleteAllPlanFeedbackCommand.java
@@ -1,0 +1,13 @@
+package ac.dnd.dodal.application.plan_feedback.dto.command;
+
+import ac.dnd.dodal.domain.plan.enums.PlanStatus;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class DeleteAllPlanFeedbackCommand {
+  private Long planId;
+  private Long historyId;
+  private PlanStatus status;
+}

--- a/src/main/java/ac/dnd/dodal/application/plan_feedback/repository/PlanFeedbackRepository.java
+++ b/src/main/java/ac/dnd/dodal/application/plan_feedback/repository/PlanFeedbackRepository.java
@@ -1,11 +1,17 @@
 package ac.dnd.dodal.application.plan_feedback.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import ac.dnd.dodal.domain.plan_feedback.model.PlanFeedback;
 import ac.dnd.dodal.domain.plan_feedback.model.PlanFeedbackId;
 
+import java.util.List;
+
 @Repository
 public interface PlanFeedbackRepository extends JpaRepository<PlanFeedback, PlanFeedbackId> {
+
+    @Query("SELECT pf FROM plan_feedbacks pf WHERE pf.plan.planId = :planId")
+    List<PlanFeedback> findAllByPlanId(Long planId);
 }

--- a/src/main/java/ac/dnd/dodal/application/plan_feedback/service/PlanFeedbackCommandService.java
+++ b/src/main/java/ac/dnd/dodal/application/plan_feedback/service/PlanFeedbackCommandService.java
@@ -1,0 +1,25 @@
+package ac.dnd.dodal.application.plan_feedback.service;
+
+import ac.dnd.dodal.application.plan_feedback.dto.command.DeleteAllPlanFeedbackCommand;
+import ac.dnd.dodal.domain.plan_feedback.model.PlanFeedback;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class PlanFeedbackCommandService {
+
+    private final PlanFeedbackService planFeedbackService;
+
+    public void deleteAll(DeleteAllPlanFeedbackCommand command) {
+        List<PlanFeedback> planFeedbacks = planFeedbackService.findAllByPlanId(command.getPlanId());
+        for (PlanFeedback feedback : planFeedbacks) {
+            feedback.delete();
+        }
+        planFeedbackService.saveAll(planFeedbacks);
+    }
+}

--- a/src/main/java/ac/dnd/dodal/application/plan_feedback/service/PlanFeedbackEventListener.java
+++ b/src/main/java/ac/dnd/dodal/application/plan_feedback/service/PlanFeedbackEventListener.java
@@ -4,6 +4,7 @@ import ac.dnd.dodal.application.plan_feedback.dto.command.DeleteAllPlanFeedbackC
 import ac.dnd.dodal.domain.plan.event.DeletedPlanEvent;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -12,6 +13,7 @@ public class PlanFeedbackEventListener {
 
     private final PlanFeedbackCommandService planFeedbackCommandService;
 
+    @Async
     @EventListener
     public void handleDeletedPlanEvent(DeletedPlanEvent event) {
         planFeedbackCommandService.deleteAll(

--- a/src/main/java/ac/dnd/dodal/application/plan_feedback/service/PlanFeedbackEventListener.java
+++ b/src/main/java/ac/dnd/dodal/application/plan_feedback/service/PlanFeedbackEventListener.java
@@ -1,0 +1,25 @@
+package ac.dnd.dodal.application.plan_feedback.service;
+
+import ac.dnd.dodal.application.plan_feedback.dto.command.DeleteAllPlanFeedbackCommand;
+import ac.dnd.dodal.domain.plan.event.DeletedPlanEvent;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class PlanFeedbackEventListener {
+
+    private final PlanFeedbackCommandService planFeedbackCommandService;
+
+    @EventListener
+    public void handleDeletedPlanEvent(DeletedPlanEvent event) {
+        planFeedbackCommandService.deleteAll(
+                new DeleteAllPlanFeedbackCommand(
+                        event.getPlanId(),
+                        event.getHistoryId(),
+                        event.getStatus()
+                )
+        );
+    }
+}

--- a/src/main/java/ac/dnd/dodal/application/plan_feedback/service/PlanFeedbackService.java
+++ b/src/main/java/ac/dnd/dodal/application/plan_feedback/service/PlanFeedbackService.java
@@ -1,13 +1,10 @@
 package ac.dnd.dodal.application.plan_feedback.service;
 
-import java.util.List;
-
-import ac.dnd.dodal.application.plan_feedback.dto.command.DeleteAllPlanFeedbackCommand;
-import lombok.RequiredArgsConstructor;
-
-import org.springframework.stereotype.Service;
 import ac.dnd.dodal.application.plan_feedback.repository.PlanFeedbackRepository;
 import ac.dnd.dodal.domain.plan_feedback.model.PlanFeedback;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/ac/dnd/dodal/application/plan_feedback/service/PlanFeedbackService.java
+++ b/src/main/java/ac/dnd/dodal/application/plan_feedback/service/PlanFeedbackService.java
@@ -2,6 +2,7 @@ package ac.dnd.dodal.application.plan_feedback.service;
 
 import java.util.List;
 
+import ac.dnd.dodal.application.plan_feedback.dto.command.DeleteAllPlanFeedbackCommand;
 import lombok.RequiredArgsConstructor;
 
 import org.springframework.stereotype.Service;
@@ -20,5 +21,9 @@ public class PlanFeedbackService {
 
     public List<PlanFeedback> saveAll(List<PlanFeedback> planFeedbacks) {
         return planFeedbackRepository.saveAll(planFeedbacks);
+    }
+
+    public List<PlanFeedback> findAllByPlanId(Long planId) {
+        return planFeedbackRepository.findAllByPlanId(planId);
     }
 }

--- a/src/main/java/ac/dnd/dodal/application/plan_history/repository/PlanHistoryRepository.java
+++ b/src/main/java/ac/dnd/dodal/application/plan_history/repository/PlanHistoryRepository.java
@@ -9,6 +9,8 @@ import org.springframework.stereotype.Repository;
 import ac.dnd.dodal.domain.plan_history.model.PlanHistory;
 import ac.dnd.dodal.ui.plan_history.response.HistoryResponse;
 
+import java.util.List;
+
 @Repository
 public interface PlanHistoryRepository extends JpaRepository<PlanHistory, Long> {
 
@@ -35,4 +37,7 @@ public interface PlanHistoryRepository extends JpaRepository<PlanHistory, Long> 
             + "WHERE ph.goal.goalId = :goalId "
             + "AND hs.historyId = :historyId")
     HistoryResponse getHistoryResponseByGoalId(Long goalId, Long historyId);
+
+    @Query("SELECT ph FROM plan_histories ph WHERE ph.goal.goalId = :goalId")
+    List<PlanHistory> findAllByGoalId(Long goalId);
 }

--- a/src/main/java/ac/dnd/dodal/application/plan_history/service/HistoryStatisticsEventListenter.java
+++ b/src/main/java/ac/dnd/dodal/application/plan_history/service/HistoryStatisticsEventListenter.java
@@ -3,6 +3,7 @@ package ac.dnd.dodal.application.plan_history.service;
 import lombok.RequiredArgsConstructor;
 
 import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 
 import ac.dnd.dodal.domain.plan_history.model.HistoryStatistics;
@@ -26,6 +27,7 @@ public class HistoryStatisticsEventListenter {
         historyStatisticsService.save(historyStatistics);
     }
 
+    @Async
     @EventListener
     public void handleDeletedPlanEvent(DeletedPlanEvent event) {
         if (event.getStatus() == PlanStatus.NONE) {

--- a/src/main/java/ac/dnd/dodal/application/plan_history/service/PlanHistoryCommandService.java
+++ b/src/main/java/ac/dnd/dodal/application/plan_history/service/PlanHistoryCommandService.java
@@ -14,7 +14,6 @@ import java.util.List;
 public class PlanHistoryCommandService {
 
     private final PlanHistoryService planHistoryService;
-    private final ApplicationEventPublisher eventPublisher;
 
     public void deleteAllByGoalId(Long goalId) {
         List<PlanHistory> planHistories = planHistoryService.findAllByGoalId(goalId);

--- a/src/main/java/ac/dnd/dodal/application/plan_history/service/PlanHistoryCommandService.java
+++ b/src/main/java/ac/dnd/dodal/application/plan_history/service/PlanHistoryCommandService.java
@@ -1,0 +1,26 @@
+package ac.dnd.dodal.application.plan_history.service;
+
+import ac.dnd.dodal.domain.plan_history.model.PlanHistory;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class PlanHistoryCommandService {
+
+    private final PlanHistoryService planHistoryService;
+    private final ApplicationEventPublisher eventPublisher;
+
+    public void deleteAllByGoalId(Long goalId) {
+        List<PlanHistory> planHistories = planHistoryService.findAllByGoalId(goalId);
+        for (PlanHistory planHistory : planHistories) {
+            planHistory.delete();
+        }
+        planHistoryService.saveAll(planHistories);
+    }
+}

--- a/src/main/java/ac/dnd/dodal/application/plan_history/service/PlanHistoryCommandService.java
+++ b/src/main/java/ac/dnd/dodal/application/plan_history/service/PlanHistoryCommandService.java
@@ -2,11 +2,9 @@ package ac.dnd.dodal.application.plan_history.service;
 
 import ac.dnd.dodal.domain.plan_history.model.PlanHistory;
 import jakarta.transaction.Transactional;
-import lombok.RequiredArgsConstructor;
-import org.springframework.context.ApplicationEventPublisher;
-import org.springframework.stereotype.Service;
-
 import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/ac/dnd/dodal/application/plan_history/service/PlanHistoryEventListener.java
+++ b/src/main/java/ac/dnd/dodal/application/plan_history/service/PlanHistoryEventListener.java
@@ -3,6 +3,7 @@ package ac.dnd.dodal.application.plan_history.service;
 import ac.dnd.dodal.domain.goal.event.DeletedGoalEvent;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -11,6 +12,7 @@ public class PlanHistoryEventListener {
 
     private final PlanHistoryCommandService planHistoryCommandService;
 
+    @Async
     @EventListener
     public void handleDeletedGoalEvent(DeletedGoalEvent event) {
         planHistoryCommandService.deleteAllByGoalId(event.getGoalId());

--- a/src/main/java/ac/dnd/dodal/application/plan_history/service/PlanHistoryEventListener.java
+++ b/src/main/java/ac/dnd/dodal/application/plan_history/service/PlanHistoryEventListener.java
@@ -7,7 +7,7 @@ import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
-public class PlanHistoryEventlistener {
+public class PlanHistoryEventListener {
 
     private final PlanHistoryCommandService planHistoryCommandService;
 

--- a/src/main/java/ac/dnd/dodal/application/plan_history/service/PlanHistoryEventlistener.java
+++ b/src/main/java/ac/dnd/dodal/application/plan_history/service/PlanHistoryEventlistener.java
@@ -1,0 +1,18 @@
+package ac.dnd.dodal.application.plan_history.service;
+
+import ac.dnd.dodal.domain.goal.event.DeletedGoalEvent;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class PlanHistoryEventlistener {
+
+    private final PlanHistoryCommandService planHistoryCommandService;
+
+    @EventListener
+    public void handleDeletedGoalEvent(DeletedGoalEvent event) {
+        planHistoryCommandService.deleteAllByGoalId(event.getGoalId());
+    }
+}

--- a/src/main/java/ac/dnd/dodal/application/plan_history/service/PlanHistoryService.java
+++ b/src/main/java/ac/dnd/dodal/application/plan_history/service/PlanHistoryService.java
@@ -1,5 +1,6 @@
 package ac.dnd.dodal.application.plan_history.service;
 
+import java.util.List;
 import java.util.Optional;
 
 import lombok.RequiredArgsConstructor;
@@ -25,6 +26,10 @@ public class PlanHistoryService {
         return planHistoryRepository.saveAndFlush(planHistory);
     }
 
+    public List<PlanHistory> saveAll(List<PlanHistory> planHistories) {
+        return planHistoryRepository.saveAll(planHistories);
+    }
+
     public Optional<PlanHistory> findById(Long planHistoryId) {
         return planHistoryRepository.findById(planHistoryId);
     }
@@ -37,5 +42,9 @@ public class PlanHistoryService {
     public void delete(PlanHistory planHistory) {
         planHistory.delete();
         planHistoryRepository.save(planHistory);
+    }
+
+    public List<PlanHistory> findAllByGoalId(Long goalId) {
+        return planHistoryRepository.findAllByGoalId(goalId);
     }
 }

--- a/src/main/java/ac/dnd/dodal/application/user/repository/UserAnswerRepository.java
+++ b/src/main/java/ac/dnd/dodal/application/user/repository/UserAnswerRepository.java
@@ -10,6 +10,6 @@ import java.util.List;
 @Repository
 public interface UserAnswerRepository extends JpaRepository<UserAnswer, Long> {
 
-    @Query("SELECT ua FROM UserAnswer ua WHERE ua.user = :user")
+    @Query("SELECT ua FROM UserAnswer ua WHERE ua.user = :user AND ua.deletedAt IS NULL")
     List<UserAnswer> findAllByUser(User user);
 }

--- a/src/main/java/ac/dnd/dodal/application/user/repository/UserAnswerRepository.java
+++ b/src/main/java/ac/dnd/dodal/application/user/repository/UserAnswerRepository.java
@@ -11,5 +11,5 @@ import java.util.List;
 public interface UserAnswerRepository extends JpaRepository<UserAnswer, Long> {
 
     @Query("SELECT ua FROM UserAnswer ua WHERE ua.user = :user")
-    List<UserAnswer> findAllByUserId(User user);
+    List<UserAnswer> findAllByUser(User user);
 }

--- a/src/main/java/ac/dnd/dodal/application/user/service/UserCommandService.java
+++ b/src/main/java/ac/dnd/dodal/application/user/service/UserCommandService.java
@@ -15,6 +15,7 @@ import ac.dnd.dodal.domain.onboarding.exception.OnBoardingNotFoundException;
 import ac.dnd.dodal.domain.onboarding.model.Answer;
 import ac.dnd.dodal.domain.user.enums.UserExceptionCode;
 import ac.dnd.dodal.domain.user.enums.UserRole;
+import ac.dnd.dodal.domain.user.event.UserWithdrawnEvent;
 import ac.dnd.dodal.domain.user.exception.UserNotFoundException;
 import ac.dnd.dodal.domain.user.model.User;
 import ac.dnd.dodal.domain.user.model.UserAnswer;
@@ -148,6 +149,8 @@ public class UserCommandService implements UserCommandUseCase, CreateUserAnswerU
     // 로그 추적을 위한 로그 출력
     log.info("User {} has been withdrawn.", user.getId());
 
-    // TODO: 회원탈퇴 시 이벤트 발행 및 관련 데이터 비동기 삭제 로직 추가
+    // TODO: 관련 데이터 비동기 삭제 로직 추가
+    eventPublisher.publishEvent(new UserWithdrawnEvent(user.getId()));
+
   }
 }

--- a/src/main/java/ac/dnd/dodal/application/user/service/UserQueryService.java
+++ b/src/main/java/ac/dnd/dodal/application/user/service/UserQueryService.java
@@ -61,7 +61,7 @@ public class UserQueryService implements UserQueryUseCase, CheckIsDoneUserAnswer
         User user = userQueryRepository.findById(userId)
                 .orElseThrow(() -> new UserNotFoundException(UserExceptionCode.NOT_FOUND_USER));
 
-        List<UserAnswer> userAnswers =  userAnswerRepository.findAllByUserId(user);
+        List<UserAnswer> userAnswers =  userAnswerRepository.findAllByUser(user);
 
         if (userAnswers.isEmpty() || userAnswers == null) {
             return GetUserAnswerResponseDto.fromUserAnswersOnboardingNotDone();

--- a/src/main/java/ac/dnd/dodal/application/user_guide/dto/command/DeleteAllUserGuideCommand.java
+++ b/src/main/java/ac/dnd/dodal/application/user_guide/dto/command/DeleteAllUserGuideCommand.java
@@ -1,0 +1,10 @@
+package ac.dnd.dodal.application.user_guide.dto.command;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class DeleteAllUserGuideCommand {
+    private Long userId;
+}

--- a/src/main/java/ac/dnd/dodal/application/user_guide/repository/UserGuideRepository.java
+++ b/src/main/java/ac/dnd/dodal/application/user_guide/repository/UserGuideRepository.java
@@ -6,10 +6,12 @@ import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import ac.dnd.dodal.domain.guide.enums.GuideType;
 import ac.dnd.dodal.domain.guide.model.UserGuide;
-import ac.dnd.dodal.domain.guide.model.UserGuideId; 
+import ac.dnd.dodal.domain.guide.model.UserGuideId;
+import org.springframework.data.jpa.repository.Query;
 
 public interface UserGuideRepository extends JpaRepository<UserGuide, UserGuideId> {
 
+    @Query("SELECT ug FROM user_guides ug WHERE ug.userId = :userId AND ug.deletedAt IS NULL")
     List<UserGuide> findAllByUserId(Long userId);
 
     Optional<UserGuide> findByUserIdAndType(Long userId, GuideType type);

--- a/src/main/java/ac/dnd/dodal/application/user_guide/service/UserGuideEventListener.java
+++ b/src/main/java/ac/dnd/dodal/application/user_guide/service/UserGuideEventListener.java
@@ -3,6 +3,8 @@ package ac.dnd.dodal.application.user_guide.service;
 import java.util.ArrayList;
 import java.util.List;
 
+import ac.dnd.dodal.application.user_guide.dto.command.DeleteAllUserGuideCommand;
+import ac.dnd.dodal.domain.user.event.UserWithdrawnEvent;
 import lombok.RequiredArgsConstructor;
 
 import org.springframework.context.event.EventListener;
@@ -35,5 +37,10 @@ public class UserGuideEventListener {
         userGuides.add(newPlanGuide);
         userGuides.add(updatePlanGuide);
         userGuideService.saveAll(userGuides);
+    }
+
+    @EventListener
+    public void onUserWithdrawnEvent(UserWithdrawnEvent event) {
+        userGuideService.deleteAll(new DeleteAllUserGuideCommand(event.getUserId()));
     }
 }

--- a/src/main/java/ac/dnd/dodal/application/user_guide/service/UserGuideEventListener.java
+++ b/src/main/java/ac/dnd/dodal/application/user_guide/service/UserGuideEventListener.java
@@ -8,6 +8,7 @@ import ac.dnd.dodal.domain.user.event.UserWithdrawnEvent;
 import lombok.RequiredArgsConstructor;
 
 import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 
 import ac.dnd.dodal.domain.onboarding.event.OnboardingProceededEvent;
@@ -39,6 +40,7 @@ public class UserGuideEventListener {
         userGuideService.saveAll(userGuides);
     }
 
+    @Async
     @EventListener
     public void onUserWithdrawnEvent(UserWithdrawnEvent event) {
         userGuideService.deleteAll(new DeleteAllUserGuideCommand(event.getUserId()));

--- a/src/main/java/ac/dnd/dodal/application/user_guide/service/UserGuideService.java
+++ b/src/main/java/ac/dnd/dodal/application/user_guide/service/UserGuideService.java
@@ -65,7 +65,9 @@ public class UserGuideService {
     @Transactional
     public void deleteAll(DeleteAllUserGuideCommand command) {
         List<UserGuide> userGuides = findAllByUserId(command.getUserId());
-
-        userGuides.forEach(this::delete);
+        for (UserGuide userGuide : userGuides) {
+            userGuide.delete();
+        }
+        userGuideRepository.saveAll(userGuides);
     }
 }

--- a/src/main/java/ac/dnd/dodal/application/user_guide/service/UserGuideService.java
+++ b/src/main/java/ac/dnd/dodal/application/user_guide/service/UserGuideService.java
@@ -2,6 +2,8 @@ package ac.dnd.dodal.application.user_guide.service;
 
 import java.util.List;
 import java.util.Optional;
+
+import ac.dnd.dodal.application.user_guide.dto.command.DeleteAllUserGuideCommand;
 import lombok.RequiredArgsConstructor;
 
 import org.springframework.stereotype.Service;
@@ -61,8 +63,8 @@ public class UserGuideService {
     }
 
     @Transactional
-    public void deleteAll(Long userId) {
-        List<UserGuide> userGuides = findAllByUserId(userId);
+    public void deleteAll(DeleteAllUserGuideCommand command) {
+        List<UserGuide> userGuides = findAllByUserId(command.getUserId());
 
         userGuides.forEach(this::delete);
     }

--- a/src/main/java/ac/dnd/dodal/common/util/OAuth2Util.java
+++ b/src/main/java/ac/dnd/dodal/common/util/OAuth2Util.java
@@ -180,7 +180,7 @@ public class OAuth2Util {
     }
   }
 
-  public void revokeAppleToken(String accessToken) {
+  public boolean revokeAppleToken(String accessToken) {
     HttpHeaders httpHeaders = new HttpHeaders();
     httpHeaders.add(Constants.CONTENT_TYPE, "application/x-www-form-urlencoded");
 
@@ -203,5 +203,7 @@ public class OAuth2Util {
       log.info("response when user revokes to use apple token : " + response);
       throw new InternalServerErrorException(SecurityExceptionCode.EXTERNAL_SERVER_ERROR);
     }
+
+    return true;
   }
 }

--- a/src/main/java/ac/dnd/dodal/core/config/AsyncConfig.java
+++ b/src/main/java/ac/dnd/dodal/core/config/AsyncConfig.java
@@ -1,0 +1,8 @@
+package ac.dnd.dodal.core.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig {}

--- a/src/main/java/ac/dnd/dodal/domain/goal/event/DeletedGoalEvent.java
+++ b/src/main/java/ac/dnd/dodal/domain/goal/event/DeletedGoalEvent.java
@@ -1,0 +1,12 @@
+package ac.dnd.dodal.domain.goal.event;
+
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+
+@Getter
+@EqualsAndHashCode
+@AllArgsConstructor
+public class DeletedGoalEvent {
+    private Long goalId;
+}

--- a/src/main/java/ac/dnd/dodal/domain/plan/event/DeletedPlanEvent.java
+++ b/src/main/java/ac/dnd/dodal/domain/plan/event/DeletedPlanEvent.java
@@ -13,6 +13,5 @@ public class DeletedPlanEvent {
 
     private final Long planId;
     private final Long historyId;
-    private final Long userId;
     private final PlanStatus status;
 }

--- a/src/main/java/ac/dnd/dodal/domain/user/event/UserWithdrawnEvent.java
+++ b/src/main/java/ac/dnd/dodal/domain/user/event/UserWithdrawnEvent.java
@@ -1,0 +1,12 @@
+package ac.dnd.dodal.domain.user.event;
+
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+
+@Getter
+@EqualsAndHashCode
+@AllArgsConstructor
+public class UserWithdrawnEvent {
+    private final Long userId;
+}

--- a/src/test/java/ac/dnd/dodal/acceptance/user/CreateUserAnswerAcceptanceTest.java
+++ b/src/test/java/ac/dnd/dodal/acceptance/user/CreateUserAnswerAcceptanceTest.java
@@ -11,11 +11,9 @@ import ac.dnd.dodal.ui.user.request.CreateUserAnswerRequestDto;
 import ac.dnd.dodal.ui.user.response.GetUserAnswerResponseDto;
 import io.restassured.common.mapper.TypeRef;
 import io.restassured.response.Response;
+import java.util.List;
 import org.junit.jupiter.api.*;
 import org.springframework.http.HttpStatus;
-import org.testcontainers.shaded.org.checkerframework.common.value.qual.DoesNotMatchRegex;
-
-import java.util.List;
 
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 public class CreateUserAnswerAcceptanceTest extends AcceptanceTest {

--- a/src/test/java/ac/dnd/dodal/acceptance/user/steps/UserSteps.java
+++ b/src/test/java/ac/dnd/dodal/acceptance/user/steps/UserSteps.java
@@ -1,13 +1,11 @@
 package ac.dnd.dodal.acceptance.user.steps;
 
-import ac.dnd.dodal.ui.feedback.request.CreateFeedbackRequest;
-import ac.dnd.dodal.ui.user.request.CreateUserAnswerRequestDto;
-import io.restassured.http.ContentType;
-import io.restassured.response.Response;
-
 import java.util.Map;
 
+import ac.dnd.dodal.ui.user.request.CreateUserAnswerRequestDto;
 import static io.restassured.RestAssured.given;
+import io.restassured.http.ContentType;
+import io.restassured.response.Response;
 
 public class UserSteps{
 

--- a/src/test/java/ac/dnd/dodal/application/goal/dto/GoalCommandFixture.java
+++ b/src/test/java/ac/dnd/dodal/application/goal/dto/GoalCommandFixture.java
@@ -2,6 +2,7 @@ package ac.dnd.dodal.application.goal.dto;
 
 import ac.dnd.dodal.application.goal.dto.command.CreateGoalCommand;
 import ac.dnd.dodal.application.goal.dto.command.AchieveGoalCommand;
+import ac.dnd.dodal.application.goal.dto.command.DeleteAllGoalCommand;
 import ac.dnd.dodal.application.goal.dto.command.DeleteGoalCommand;
 
 public class GoalCommandFixture {
@@ -48,5 +49,9 @@ public class GoalCommandFixture {
 
     public static DeleteGoalCommand deleteGoalCommand() {
         return deleteGoalCommand(USER_ID, GOAL_ID);
+    }
+
+    public static DeleteAllGoalCommand deleteAllGoalCommand() {
+        return new DeleteAllGoalCommand(USER_ID);
     }
 }

--- a/src/test/java/ac/dnd/dodal/application/goal/service/GoalCommandServiceTest.java
+++ b/src/test/java/ac/dnd/dodal/application/goal/service/GoalCommandServiceTest.java
@@ -1,26 +1,15 @@
 package ac.dnd.dodal.application.goal.service;
 
-import static org.mockito.Mockito.when;
-
-import static org.mockito.ArgumentMatchers.argThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.lenient;
-import static org.mockito.Mockito.verify;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
-import ac.dnd.dodal.domain.user.event.UserWithdrawnEvent;
-import org.mockito.Mock;
-import org.mockito.InjectMocks;
-import org.mockito.junit.jupiter.MockitoExtension;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.extension.ExtendWith;
-
-import org.springframework.test.util.ReflectionTestUtils;
-import org.springframework.context.ApplicationEventPublisher;
-
+import ac.dnd.dodal.application.goal.dto.GoalCommandFixture;
+import ac.dnd.dodal.application.goal.dto.command.*;
 import ac.dnd.dodal.common.exception.BadRequestException;
 import ac.dnd.dodal.common.exception.ForbiddenException;
 import ac.dnd.dodal.common.exception.UnauthorizedException;
@@ -28,10 +17,16 @@ import ac.dnd.dodal.domain.goal.GoalFixture;
 import ac.dnd.dodal.domain.goal.event.GoalCreatedEvent;
 import ac.dnd.dodal.domain.goal.exception.GoalExceptionCode;
 import ac.dnd.dodal.domain.goal.model.Goal;
-import ac.dnd.dodal.application.goal.dto.command.*;
-import ac.dnd.dodal.application.goal.dto.GoalCommandFixture;
-
 import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
 public class GoalCommandServiceTest {

--- a/src/test/java/ac/dnd/dodal/application/goal/service/GoalCommandServiceTest.java
+++ b/src/test/java/ac/dnd/dodal/application/goal/service/GoalCommandServiceTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.verify;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import ac.dnd.dodal.domain.user.event.UserWithdrawnEvent;
 import org.mockito.Mock;
 import org.mockito.InjectMocks;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -29,6 +30,8 @@ import ac.dnd.dodal.domain.goal.exception.GoalExceptionCode;
 import ac.dnd.dodal.domain.goal.model.Goal;
 import ac.dnd.dodal.application.goal.dto.command.*;
 import ac.dnd.dodal.application.goal.dto.GoalCommandFixture;
+
+import java.util.List;
 
 @ExtendWith(MockitoExtension.class)
 public class GoalCommandServiceTest {
@@ -213,7 +216,7 @@ public class GoalCommandServiceTest {
     @Test
     @DisplayName("Delete a goal which is already deleted")
     void delete_goal_already_deleted() {
-        // given
+    // given
         DeleteGoalCommand command = GoalCommandFixture.deleteGoalCommand(userId, goalId);
         when(goalService.findByIdOrThrow(goalId))
             .thenReturn(deletedGoal);
@@ -223,4 +226,19 @@ public class GoalCommandServiceTest {
                 .isInstanceOf(ForbiddenException.class)
                 .hasMessage(GoalExceptionCode.GOAL_ALREADY_DELETED.getMessage());
     }
+
+    @Test
+    @DisplayName("사용자의 모든 목표를 삭제한다.")
+    void delete_all_goals_when_user_withdrawn() {
+        // given
+        DeleteAllGoalCommand command = GoalCommandFixture.deleteAllGoalCommand();
+        when(goalService.findAllByUserId(userId)).thenReturn(List.of(goal));
+
+        // when
+        goalCommandService.deleteAll(command);
+
+        // then
+        verify(goalService).saveAll(argThat(goals -> goals.getFirst().getDeletedAt() != null));
+    }
+
 }

--- a/src/test/java/ac/dnd/dodal/application/goal/service/GoalEventListenerTest.java
+++ b/src/test/java/ac/dnd/dodal/application/goal/service/GoalEventListenerTest.java
@@ -1,0 +1,61 @@
+package ac.dnd.dodal.application.goal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import ac.dnd.dodal.application.goal.repository.GoalRepository;
+import ac.dnd.dodal.application.user.dto.UserCommandFixture;
+import ac.dnd.dodal.application.user.service.UserCommandService;
+import ac.dnd.dodal.domain.goal.model.Goal;
+import ac.dnd.dodal.domain.user.event.UserWithdrawnEvent;
+import ac.dnd.dodal.domain.user.model.User;
+import ac.dnd.dodal.ui.auth.request.OAuthUserInfoRequestDto;
+import jakarta.transaction.Transactional;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@Transactional
+public class GoalEventListenerTest {
+
+    @Autowired
+    private ApplicationEventPublisher eventPublisher;
+    
+    @Autowired
+    private UserCommandService userCommandService;
+
+    @Autowired
+    private GoalRepository goalRepository;
+
+    @Test
+    @DisplayName("사용자가 탈퇴 시 사용자와 관계된 모든 목표들이 삭제된다.")
+    void delete_user_all_goals_when_user_withdrawn() {
+        //given
+        OAuthUserInfoRequestDto authSignUpRequestDto = UserCommandFixture.signUpUser();
+        User user = userCommandService.createUserBySocialSignUp(authSignUpRequestDto);
+
+        List<Goal> goals = List.of(
+                new Goal(user.getId(), "goal1"),
+                new Goal(user.getId(), "goal2")
+        );
+        goalRepository.saveAll(goals);
+        assertThat(goals.getLast().getDeletedAt()).isNull();
+        eventPublisher.publishEvent(new UserWithdrawnEvent(user.getId()));
+
+        try{
+            Thread.sleep(1000);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+
+        //when&then
+        assertThat(goals).hasSize(2);
+        assertThat(goals.getFirst().getDeletedAt()).isNotNull();
+        assertThat(goals.getLast().getDeletedAt()).isNotNull();
+    }
+}

--- a/src/test/java/ac/dnd/dodal/application/goal/service/GoalStatisticsEventListenerTest.java
+++ b/src/test/java/ac/dnd/dodal/application/goal/service/GoalStatisticsEventListenerTest.java
@@ -3,21 +3,10 @@ package ac.dnd.dodal.application.goal.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertThrows;
 
-import ac.dnd.dodal.application.goal.repository.GoalRepository;
-import ac.dnd.dodal.application.user.dto.UserCommandFixture;
-import ac.dnd.dodal.application.user.service.UserCommandService;
-import ac.dnd.dodal.common.exception.NotFoundException;
-import ac.dnd.dodal.domain.goal.event.DeletedGoalEvent;
-import ac.dnd.dodal.domain.user.model.User;
-import ac.dnd.dodal.ui.auth.request.OAuthUserInfoRequestDto;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.ApplicationEventPublisher;
-
 import ac.dnd.dodal.IntegrationTest;
+import ac.dnd.dodal.common.exception.NotFoundException;
 import ac.dnd.dodal.domain.goal.GoalFixture;
+import ac.dnd.dodal.domain.goal.event.DeletedGoalEvent;
 import ac.dnd.dodal.domain.goal.event.GoalCreatedEvent;
 import ac.dnd.dodal.domain.goal.model.Goal;
 import ac.dnd.dodal.domain.goal.model.GoalStatistics;
@@ -25,8 +14,10 @@ import ac.dnd.dodal.domain.plan.PlanFixture;
 import ac.dnd.dodal.domain.plan.event.PlanCompletedEvent;
 import ac.dnd.dodal.domain.plan.model.Plan;
 import ac.dnd.dodal.domain.plan_feedback.model.PlanFeedback;
-
-import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationEventPublisher;
 
 public class GoalStatisticsEventListenerTest extends IntegrationTest {
 

--- a/src/test/java/ac/dnd/dodal/application/plan/service/PlanEventListenerTest.java
+++ b/src/test/java/ac/dnd/dodal/application/plan/service/PlanEventListenerTest.java
@@ -1,0 +1,44 @@
+package ac.dnd.dodal.application.plan.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import ac.dnd.dodal.IntegrationTest;
+import ac.dnd.dodal.application.plan.repository.PlanRepository;
+import ac.dnd.dodal.domain.goal.GoalFixture;
+import ac.dnd.dodal.domain.goal.event.DeletedGoalEvent;
+import ac.dnd.dodal.domain.plan.model.Plan;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationEventPublisher;
+
+public class PlanEventListenerTest extends IntegrationTest {
+
+    @Autowired
+    private ApplicationEventPublisher eventPublisher;
+
+    @Autowired
+    private PlanService planService;
+
+    @Test
+    @DisplayName("목표가 삭제되면 해당 목표에 속한 모든 계획이 삭제된다.")
+    void delete_all_plans_when_goal_deleted() {
+        // given
+        Long goalId = GoalFixture.goal().getGoalId();
+        List<Plan> plans = planService.findAllByGoalId(goalId);
+        assertThat(plans.getLast().getDeletedAt()).isNull();
+
+        // when
+        eventPublisher.publishEvent(new DeletedGoalEvent(goalId));
+        
+        try {
+            Thread.sleep(1000);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+        
+        // then
+        assertThat(plans.getLast().getDeletedAt()).isNotNull();
+    }
+}

--- a/src/test/java/ac/dnd/dodal/application/plan/service/PlanEventListenerTest.java
+++ b/src/test/java/ac/dnd/dodal/application/plan/service/PlanEventListenerTest.java
@@ -3,7 +3,6 @@ package ac.dnd.dodal.application.plan.service;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import ac.dnd.dodal.IntegrationTest;
-import ac.dnd.dodal.application.plan.repository.PlanRepository;
 import ac.dnd.dodal.domain.goal.GoalFixture;
 import ac.dnd.dodal.domain.goal.event.DeletedGoalEvent;
 import ac.dnd.dodal.domain.plan.model.Plan;

--- a/src/test/java/ac/dnd/dodal/application/plan_feedback/service/PlanFeedbackEventListenerTest.java
+++ b/src/test/java/ac/dnd/dodal/application/plan_feedback/service/PlanFeedbackEventListenerTest.java
@@ -1,0 +1,49 @@
+package ac.dnd.dodal.application.plan_feedback.service;
+
+import ac.dnd.dodal.IntegrationTest;
+import ac.dnd.dodal.domain.plan.PlanFixture;
+import ac.dnd.dodal.domain.plan.event.DeletedPlanEvent;
+import ac.dnd.dodal.domain.plan.model.Plan;
+import ac.dnd.dodal.domain.plan_feedback.model.PlanFeedback;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationEventPublisher;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class PlanFeedbackEventListenerTest extends IntegrationTest {
+
+    @Autowired
+    private ApplicationEventPublisher eventPublisher;
+
+    @Autowired
+    private PlanFeedbackService planFeedbackService;
+
+    @Test
+    @DisplayName("계획이 삭제되면 해당 계획과 관련된 모든 계획 피드백이 삭제된다.")
+    void delete_all_plan_feedbacks_when_plan_deleted() {
+        // given
+        Plan plan = PlanFixture.plan();
+        List<PlanFeedback> planFeedbacks = planFeedbackService.findAllByPlanId(plan.getPlanId());
+        assertThat(planFeedbacks).isNotEmpty();
+        assertThat(planFeedbacks.getFirst().getDeletedAt()).isNull();
+        assertThat(planFeedbacks.getLast().getDeletedAt()).isNull();
+        // when
+        eventPublisher.publishEvent(new DeletedPlanEvent(
+                plan.getPlanId(), plan.getHistory().getHistoryId(), plan.getStatus()
+        ));
+
+        try {
+            Thread.sleep(1000);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+
+        // then
+        assertThat(planFeedbacks.getFirst().getDeletedAt()).isNotNull();
+        assertThat(planFeedbacks.getLast().getDeletedAt()).isNotNull();
+    }
+}

--- a/src/test/java/ac/dnd/dodal/application/plan_history/service/PlanHistoryEventListenerTest.java
+++ b/src/test/java/ac/dnd/dodal/application/plan_history/service/PlanHistoryEventListenerTest.java
@@ -1,17 +1,15 @@
 package ac.dnd.dodal.application.plan_history.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import ac.dnd.dodal.IntegrationTest;
-import ac.dnd.dodal.application.plan.service.PlanService;
 import ac.dnd.dodal.application.plan_history.repository.PlanHistoryRepository;
 import ac.dnd.dodal.domain.goal.GoalFixture;
 import ac.dnd.dodal.domain.goal.event.DeletedGoalEvent;
-import ac.dnd.dodal.domain.goal.model.Goal;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationEventPublisher;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 public class PlanHistoryEventListenerTest extends IntegrationTest {
 

--- a/src/test/java/ac/dnd/dodal/application/plan_history/service/PlanHistoryEventListenerTest.java
+++ b/src/test/java/ac/dnd/dodal/application/plan_history/service/PlanHistoryEventListenerTest.java
@@ -1,0 +1,49 @@
+package ac.dnd.dodal.application.plan_history.service;
+
+import ac.dnd.dodal.IntegrationTest;
+import ac.dnd.dodal.application.plan.service.PlanService;
+import ac.dnd.dodal.application.plan_history.repository.PlanHistoryRepository;
+import ac.dnd.dodal.domain.goal.GoalFixture;
+import ac.dnd.dodal.domain.goal.event.DeletedGoalEvent;
+import ac.dnd.dodal.domain.goal.model.Goal;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationEventPublisher;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class PlanHistoryEventListenerTest extends IntegrationTest {
+
+    @Autowired
+    private ApplicationEventPublisher eventPublisher;
+
+    @Autowired
+    private PlanHistoryCommandService planHistoryCommandService;
+
+    @Autowired
+    private PlanHistoryRepository planHistoryRepository;
+
+    @Test
+    @DisplayName("목표 삭제 시 목표에 대항하는 계획 이력도 삭제된다.")
+    void delete_all_plan_histories_when_goal_deleted() {
+        // given
+        Long goalId = GoalFixture.goal().getGoalId();
+        assertThat(planHistoryRepository.findAllByGoalId(goalId)).isNotEmpty();
+        assertThat(planHistoryRepository.findAllByGoalId(goalId).getFirst().getDeletedAt()).isNull();
+        assertThat(planHistoryRepository.findAllByGoalId(goalId).getLast().getDeletedAt()).isNull();
+
+        // when
+        eventPublisher.publishEvent(new DeletedGoalEvent(goalId));
+
+        try {
+            Thread.sleep(1000);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+
+        // then
+        assertThat(planHistoryRepository.findAllByGoalId(goalId).getFirst().getDeletedAt()).isNotNull();
+        assertThat(planHistoryRepository.findAllByGoalId(goalId).getLast().getDeletedAt()).isNotNull();
+    }
+}

--- a/src/test/java/ac/dnd/dodal/application/user/dto/AuthSignUpFixture.java
+++ b/src/test/java/ac/dnd/dodal/application/user/dto/AuthSignUpFixture.java
@@ -6,7 +6,7 @@ import ac.dnd.dodal.domain.user.model.User;
 public class AuthSignUpFixture {
 
   public static User signUpUser() {
-    return UserFixture.createUser("test2@test.example.com", "testUser2", "profileImageURLExample2", "deviceTokenExample2");
+    return UserFixture.createUser();
   }
 
 }

--- a/src/test/java/ac/dnd/dodal/application/user/dto/UserQueryFixture.java
+++ b/src/test/java/ac/dnd/dodal/application/user/dto/UserQueryFixture.java
@@ -6,6 +6,6 @@ import ac.dnd.dodal.domain.user.model.User;
 public class UserQueryFixture {
 
     public static User saveUser() {
-        return UserFixture.createUser("test@test.example.com", "testUser", "profileImageURLExample", "deviceTokenExample");
+        return UserFixture.createUser();
     }
 }

--- a/src/test/java/ac/dnd/dodal/application/user/service/AuthRelatedServiceTest.java
+++ b/src/test/java/ac/dnd/dodal/application/user/service/AuthRelatedServiceTest.java
@@ -1,4 +1,5 @@
 package ac.dnd.dodal.application.user.service;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 

--- a/src/test/java/ac/dnd/dodal/application/user/service/UserCommandServiceTest.java
+++ b/src/test/java/ac/dnd/dodal/application/user/service/UserCommandServiceTest.java
@@ -6,11 +6,9 @@ import static org.mockito.Mockito.when;
 
 import ac.dnd.dodal.application.user.dto.UserCommandFixture;
 import ac.dnd.dodal.application.user.repository.UserAnswerRepository;
-import ac.dnd.dodal.application.user.repository.UserRepository;
 import ac.dnd.dodal.common.util.OAuth2Util;
 import ac.dnd.dodal.domain.onboarding.enums.AnswerContent;
 import ac.dnd.dodal.domain.user.enums.UserRole;
-import ac.dnd.dodal.domain.user.event.UserWithdrawnEvent;
 import ac.dnd.dodal.domain.user.model.User;
 import ac.dnd.dodal.domain.user.model.UserAnswer;
 import ac.dnd.dodal.ui.auth.request.OAuthUserInfoRequestDto;
@@ -20,13 +18,10 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Captor;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 

--- a/src/test/java/ac/dnd/dodal/application/user/service/UserCommandServiceTest.java
+++ b/src/test/java/ac/dnd/dodal/application/user/service/UserCommandServiceTest.java
@@ -2,15 +2,12 @@ package ac.dnd.dodal.application.user.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import ac.dnd.dodal.application.user.dto.UserCommandFixture;
 import ac.dnd.dodal.application.user.repository.UserAnswerRepository;
 import ac.dnd.dodal.application.user.repository.UserRepository;
 import ac.dnd.dodal.common.util.OAuth2Util;
-import ac.dnd.dodal.domain.goal.event.GoalCreatedEvent;
 import ac.dnd.dodal.domain.onboarding.enums.AnswerContent;
 import ac.dnd.dodal.domain.user.enums.UserRole;
 import ac.dnd.dodal.domain.user.event.UserWithdrawnEvent;
@@ -18,7 +15,6 @@ import ac.dnd.dodal.domain.user.model.User;
 import ac.dnd.dodal.domain.user.model.UserAnswer;
 import ac.dnd.dodal.ui.auth.request.OAuthUserInfoRequestDto;
 import ac.dnd.dodal.ui.user.request.WithdrawUserRequestDto;
-import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -30,7 +26,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
@@ -42,22 +37,13 @@ import org.springframework.transaction.annotation.Transactional;
 public class UserCommandServiceTest {
 
     @Autowired
-    private UserRepository userRepository;
-
-    @Autowired
     private UserAnswerRepository userAnswerRepository;
-
-    @Autowired
-    private ApplicationEventPublisher eventPublisher;
 
     @Autowired
     private UserCommandService userCommandService;
 
     @MockBean
     private OAuth2Util oAuth2Util;
-
-    @Captor
-    private ArgumentCaptor<UserWithdrawnEvent> eventCaptor;
 
     private OAuthUserInfoRequestDto authSignUpRequestDto;
     private User mockUser;

--- a/src/test/java/ac/dnd/dodal/application/user_guide/service/UserGuideEventListenerTest.java
+++ b/src/test/java/ac/dnd/dodal/application/user_guide/service/UserGuideEventListenerTest.java
@@ -1,0 +1,46 @@
+package ac.dnd.dodal.application.user_guide.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import ac.dnd.dodal.IntegrationTest;
+import ac.dnd.dodal.domain.guide.model.UserGuide;
+import ac.dnd.dodal.domain.user.UserFixture;
+import ac.dnd.dodal.domain.user.event.UserWithdrawnEvent;
+import java.util.List;
+
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationEventPublisher;
+
+public class UserGuideEventListenerTest extends IntegrationTest {
+
+    @Autowired
+    private ApplicationEventPublisher eventPublisher;
+
+    @Autowired
+    private UserGuideService userGuideService;
+
+    @Test
+    @DisplayName("사용자 탈퇴 시 사용자 가이드들을 모두 삭제한다.")
+    void delete_all_user_guides_when_user_deleted() {
+        // given
+        Long userId = UserFixture.USER_ID;
+        List<UserGuide> userGuides = userGuideService.findAllByUserId(userId);
+        assertThat(userGuides.getLast().getDeletedAt()).isNull();
+        assertThat(userGuides).isNotEmpty();
+
+        // when
+        eventPublisher.publishEvent(new UserWithdrawnEvent(userId));
+
+        try {
+            Thread.sleep(1000);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+
+        // then
+        assertThat(userGuides.getLast().getDeletedAt()).isNotNull();
+    }
+}

--- a/src/test/java/ac/dnd/dodal/application/user_guide/service/UserGuideEventListenerTest.java
+++ b/src/test/java/ac/dnd/dodal/application/user_guide/service/UserGuideEventListenerTest.java
@@ -7,8 +7,6 @@ import ac.dnd.dodal.domain.guide.model.UserGuide;
 import ac.dnd.dodal.domain.user.UserFixture;
 import ac.dnd.dodal.domain.user.event.UserWithdrawnEvent;
 import java.util.List;
-
-import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/src/test/java/ac/dnd/dodal/domain/user/UserFixture.java
+++ b/src/test/java/ac/dnd/dodal/domain/user/UserFixture.java
@@ -6,6 +6,7 @@ import ac.dnd.dodal.ui.auth.request.OAuthUserInfoRequestDto;
 
 public class UserFixture {
 
+  public static final Long USER_ID = 1L;
   private static final String EMAIL = "testEmail@test.example";
   private static final String NICKNAME = "testUser";
   private static final String profileImage = "testProfileImageURL";
@@ -19,7 +20,7 @@ public class UserFixture {
     return new OAuthUserInfoRequestDto(NICKNAME, EMAIL, profileImage, appleId, deviceToken);
   }
 
-  public static User createUser(String email, String nickname, String profileImageUrl, String deviceToken) {
+  public static User createUser() {
     return new User("testUser", "testUserProfileImageUrl", "testDeviceToken", "testEmail@test.example", UserRole.USER);
   }
 }


### PR DESCRIPTION
## #️⃣ Related Issue

Linked Feature backlog: #82 

## 📝 Purpose of PR

회원 탈퇴 시 회원에 연관된 엔티티들을 삭제

## Contents

탈퇴 시 회원과 관련된 엔티티를 삭제하는 방향으로 정책 변경
statistics는 BaseEntity를 상속하지 않기에 soft delete 시키지 않고 바로 삭제시키고, 
다른 테이블들은 deletedAt이 존재하기에 soft delete 처리

User, UserAnswer은 User 도메인에서 처리하고 나머지 엔티티들은 Event를 발행하여 이벤트 기반으로 동작 

## Checklist

-   [ ] Does commit messages follow the convention?
-   [ ] Are variable names brief but descriptive?
-   [ ] Is the code clean and easy to understand?
-   [ ] If a new feature has been added, or a bug fixed, has a test been added to confirm good behavior?
-   [ ] Does the test successfully test edge and corner cases?

## 💬 Review Requirements (Optional)

Is there anything you can praise about this PR? Start with praise.
Make a review, leaving kind comments and suggesting changes where needed (to resolve the above).
